### PR TITLE
♿️ a11y: Fix a11y issues in navigation, body text, and footer structures

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -42,7 +42,11 @@ h2, h4, #toctitle { color: var(--accent-color); }
 
 .dropdown-menu { background-color: var(--accent-color); }
 
-.navbar-light .navbar-nav .nav-link { color: var(--secondary); }
+/* Ensure navbar links are fully opaque to resolve transparency errors */
+.navbar-light .navbar-nav .nav-link {
+  color: var(--secondary);
+  opacity: 1; /* Override Bootstrap's default opacity */
+}
 
 .navbar li a {
   background-color: var(--primary);
@@ -62,9 +66,18 @@ h2, h4, #toctitle { color: var(--accent-color); }
 
 /* ===[ Main body styling ]=== */
 
+main a {
+  color: #0056b3; /* Darken the default link color to pass 4.5:1 contrast */
+  text-decoration: underline;
+}
+
+main a:hover {
+  color: #003d82;
+}
+
 main #projects-carousel .pc-fixed-height { height: 10vh; }
 
-main #projects h3 { 
+main #projects h3 {
   background-color: var(--primary);
   color: var(--secondary);
 }

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,8 +7,10 @@
     </div>
     {{ end }}
     <div class="container-fluid rounded m-2" id="footer-box">
-        {{ site.Title }} &copy; <a href="https://creativecommons.org/licenses/by-sa/4.0/" title="Creative Commons Attribution-ShareAlike 4.0 International" target="_blank">CC BY-SA 4.0</a>. {{ .Site.Params.biography.first_online }}-{{ now.Format "2006" }}.<br />
-        <a href="{{ .Site.Params.git_repo }}" title="{{ .Site.Params.git_repo }}">{{ i18n "footer.find_this_site" | safeHTML }}</a>
+        <p>
+            {{ site.Title }} &copy; <a href="https://creativecommons.org/licenses/by-sa/4.0/" title="Creative Commons Attribution-ShareAlike 4.0 International" target="_blank">CC BY-SA 4.0</a>. {{ .Site.Params.biography.first_online }}-{{ now.Format "2006" }}.<br />
+            <a href="{{ .Site.Params.git_repo }}" title="{{ .Site.Params.git_repo }}">{{ i18n "footer.find_this_site" | safeHTML }}</a>
+        </p>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -25,7 +25,7 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">translations</a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-                            <select id="select-language" onchange="location = this.value;">
+                            <select id="select-language" onchange="location = this.value;" aria-label="Select language">
                             {{ $siteLanguages := site.Languages}}
                             {{ $pageLang := .Page.Lang}}
                             {{ range .Page.AllTranslations }}


### PR DESCRIPTION
This commit addresses several accessibility (a11y) violations discovered during an automated Pa11y audit of the theme's example site. The overarching goal is to ensure the theme meets WCAG AA standards and can successfully pass an automated CI accessibility pipeline without warnings or errors.

The following specific improvements have been made:

- **Provide an accessible name for the language translation selector**: In `layouts/partials/nav.html`, the `<select>` dropdown for switching languages lacked an accessible name. This meant screen readers and assistive technologies could not announce the purpose of the dropdown to visually impaired users. An `aria-label="Select language"` attribute was added to explicitly define the control's purpose.

- **Resolve link contrast failures and static analysis transparency warnings**: In `assets/css/main.css`, two distinct link styling issues were fixed: * Main body links previously had a contrast ratio of 4.27:1 against the background, falling short of the WCAG AA minimum requirement of 4.5:1. The default link color was darkened to `#0056b3` to ensure sufficient visual contrast. * Bootstrap's default navigation link classes apply a transparency (opacity) effect. Because automated tools cannot statically determine the final rendered contrast of transparent elements, this triggered an accessibility failure. An `opacity: 1` override was added to the navbar links to make them fully opaque, satisfying the audit tools while maintaining the intended design.

- **Improve semantic structure of footer copyright information**: In `layouts/partials/footer.html`, the copyright and repository links were previously placed loosely inside a generic `<div>` tag. Because there were multiple sibling anchor tags, the accessibility parser incorrectly flagged the section as a potential navigation menu that should be marked up as an HTML list (`<ul>`). Wrapping this content in a paragraph (`<p>`) tag provides the correct semantic meaning for standard document text, resolving the structural warning.