### PR TITLE
♿ a11y: Set solid background color on navbar to fix transparency error

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -36,6 +36,7 @@ h2, h4, #toctitle { color: var(--accent-color); }
 /* ===[ Site navigation styling ]=== */
 
 .navbar {
+  background-color: var(--primary);
   position: fixed;
   z-index: 100;
 }


### PR DESCRIPTION
Bootstrap's `.navbar-light` defaults to a transparent background, which prevents accessibility tools from computing a contrast ratio for `nav` links. Setting `background-color` to the primary theme color gives the `navbar` a fully opaque background, resolving the Pa11y transparency error that appeared on every audited page.

Assisted-by: Claude Sonnet 4.6 (1M context)