### PR TITLE
♿ a11y: Replace footer paragraph with list for link markup

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,10 +7,10 @@
     </div>
     {{ end }}
     <div class="container-fluid rounded m-2" id="footer-box">
-        <p>
-            {{ site.Title }} &copy; <a href="https://creativecommons.org/licenses/by-sa/4.0/" title="Creative Commons Attribution-ShareAlike 4.0 International" target="_blank">CC BY-SA 4.0</a>. {{ .Site.Params.biography.first_online }}-{{ now.Format "2006" }}.<br />
-            <a href="{{ .Site.Params.git_repo }}" title="{{ .Site.Params.git_repo }}">{{ i18n "footer.find_this_site" | safeHTML }}</a>
-        </p>
+        <ul class="list-unstyled">
+            <li>{{ site.Title }} &copy; <a href="https://creativecommons.org/licenses/by-sa/4.0/" title="Creative Commons Attribution-ShareAlike 4.0 International" target="_blank">CC BY-SA 4.0</a>. {{ .Site.Params.biography.first_online }}-{{ now.Format "2006" }}.</li>
+            <li><a href="{{ .Site.Params.git_repo }}" title="{{ .Site.Params.git_repo }}">{{ i18n "footer.find_this_site" | safeHTML }}</a></li>
+        </ul>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>


### PR DESCRIPTION
Pa11y flagged the footer-box paragraph as a navigation section lacking proper list markup. The paragraph contained two links (license and git repository) that Pa11y interpreted as navigation items. Replacing the paragraph with an unstyled unordered list gives the links proper semantic list structure while preserving the existing visual layout.

Assisted-by: Claude Sonnet 4.6 (1M context)