### PR TITLE
♿ a11y: Prefix blockquote attributions with em dash

### DIFF
--- a/exampleSite/content/projects/1-education.en.md
+++ b/exampleSite/content/projects/1-education.en.md
@@ -16,7 +16,7 @@ From an early point in her life, her parents pushed Clark to pursue an education
 > There were times we didn’t want to go.
 > I cried one morning I didn’t want to go to that school, and he whipped me with a strap and then took me down there”
 >
-> _Charron-Cline_
+> — _Charron-Cline_
 
 One thing that stood out to Clark as a Black student in the 1910s was the lack of Black teachers to teach children.
 Many segregated schools had white teachers teaching black children.
@@ -28,7 +28,7 @@ This also led to Clark’s first experience with political organizing in 1919:
 > I took my students along with me, and we got these signatures.
 > Some would be across the street, and then I’d do it on the other side, and that’s how we did it”
 >
-> _Charron-Cline_
+> — _Charron-Cline_
 
 Ultimately, Clark was pushed towards education at an early age and soon realized the political power that education affords.
 This was a formational experience in her political activist career.

--- a/exampleSite/content/projects/2-naacp.en.md
+++ b/exampleSite/content/projects/2-naacp.en.md
@@ -25,7 +25,7 @@ However, there are moments where Clark reflects on knowing her allies do not ful
 > She got angry with me when I said that she was vitriolic.
 > She didn’t like that. But it was true”
 >
-> _Charron-Cline_
+> — _Charron-Cline_
 
 Despite the challenges of interracial relationships, Clark realized that all women were empowered through the role of teaching.
 This became a grounding aspect of her activism and enabled her to link her activism with civic duty and organization.
@@ -34,6 +34,6 @@ Her teaching was a vehicle for her to help other woman gain greater autonomy and
 
 > “First, when compared to losing one’s job, facing eviction from a white landlord, or risking one’s life by participating in direct action campaigns, teaching adults to read and write appeared a relatively safe entry point into the Movement.”
 >
-> _Charron-Cline_
+> — _Charron-Cline_
 
 Ultimately, despite these challenges and setbacks, Septima Clark was able to persist and continue her teaching through the Civil Rights period, even if it required relocating across the Southeast a couple of times.

--- a/exampleSite/content/projects/3-civil-rights-movement.en.md
+++ b/exampleSite/content/projects/3-civil-rights-movement.en.md
@@ -19,7 +19,7 @@ Clark kept her Citizenship Schools curriculum relevant and updated to contempora
 
 > “Training sessions and teaching classes afforded grassroots African American women the opportunity to evaluate the local problems they deemed most important while the Movement itself provided a vehicle for addressing them.”
 >
-> _Charron-Cline_
+> — _Charron-Cline_
 
 In this unique way, Clark’s impact goes beyond herself, but also to the many students who were taught under her leadership, and then returned to teach citizenship skills in their communities.
 This is also why she is sometimes left out of the retelling of history because her role was often behind the scenes and not visible.


### PR DESCRIPTION
Pa11y flagged standalone italic attribution lines in blockquotes as potential headings. A paragraph containing only emphasized text, such as `<p><em>Charron-Cline</em></p>`, is indistinguishable from a heading to an accessibility tool. Prefixing each attribution with an em dash (—) makes the semantic intent clear: this is a citation, not a heading.

Assisted-by: Claude Sonnet 4.6 (1M context)