### PR TITLE
♿ a11y: Expand `nav-link` CSS override to cover all Bootstrap states

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -43,10 +43,11 @@ h2, h4, #toctitle { color: var(--accent-color); }
 
 .dropdown-menu { background-color: var(--accent-color); }
 
-/* Ensure navbar links are fully opaque to resolve transparency errors */
-.navbar-light .navbar-nav .nav-link {
+/* Override Bootstrap's rgba nav-link colors for all states */
+.navbar-light .navbar-nav .nav-link,
+.navbar-light .navbar-nav .nav-link.active,
+.navbar-light .navbar-nav .show > .nav-link {
   color: var(--secondary);
-  opacity: 1; /* Override Bootstrap's default opacity */
 }
 
 .navbar li a {


### PR DESCRIPTION
Bootstrap 5 applies `rgba()` text colors to `navbar` links at varying CSS specificities. The `.nav-link.active` and `.show > .nav-link` states use specificity (0,4,0,0), which was beating our single-selector override at (0,3,0,0). Expanding the selector to cover all three states ensures our solid color value wins the cascade in every case, eliminating the transparency that Pa11y detected on the active nav link.

Assisted-by: Claude Sonnet 4.6 (1M context)