### PR TITLE
🎨 ui: Pin `navbar` flush to viewport and improve visual hierarchy

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -40,21 +40,28 @@ h2, h4, #toctitle { color: var(--accent-color); }
   --bs-navbar-hover-color: var(--secondary);
   --bs-navbar-active-color: var(--secondary);
   background-color: var(--primary);
+  border-bottom: 2px solid var(--accent-color);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   z-index: 100;
 }
 
 .dropdown-menu { background-color: var(--accent-color); }
 
 .navbar .nav-link,
-.navbar .nav-link.active,
 .navbar .nav-link:hover,
 .navbar .nav-link:focus {
   background-color: var(--primary);
-  border-color: var(--accent-color);
-  border-style: solid;
   color: var(--secondary);
   text-align: center;
+}
+
+.navbar .nav-link.active {
+  background-color: var(--accent-color);
+  color: var(--secondary);
 }
 
 .navbar .nav-link:hover {

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg ms-3 mt-2">
+<nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
         <button class="navbar-toggler bg-light" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
The `navbar` previously used Bootstrap margin utilities (`ms-3`, `mt-2`) that pushed it away from the viewport edges, creating a "floating" effect in the upper-right corner. This made the navigation feel detached from the page structure.

Pin the `navbar` flush to the top of the viewport spanning full-width by removing the margin classes and adding explicit top/left/right positioning. This follows the conventional fixed-navbar pattern that users expect and establishes clear visual hierarchy.

Add a bottom border in the accent color and a subtle box-shadow to visually separate the navbar from page content. The navbar background uses the primary color, which is shared with page headers and project sections — without a border, the navbar blends into these elements when scrolled to those positions on the page.

Remove individual nav-link borders that added visual clutter. With the container-level border now providing separation, per-link borders are redundant.

Give the active nav-link a distinct background color using the accent color, so users can identify which page they are currently visiting. The three nav-link states are now visually distinct: primary background for available links, accent background for the current page, and `royalblue` on hover for interactive feedback.

Assisted-by: Claude Opus 4.6 (1M context)

<img width="1023" height="670" alt='A webpage screenshot emphasizing a full-width, deep red top navigation bar containing the white text links "home," "about me," and a "social" dropdown menu. The active "home" link is visually distinguished by a greyish-olive background block. Below the navigation bar is the top portion of a biographical page for Septima Poinsette Clark, including her name, portrait, and introductory text.' title='A webpage screenshot emphasizing a full-width, deep red top navigation bar containing the white text links "home," "about me," and a "social" dropdown menu. The active "home" link is visually distinguished by a greyish-olive background block. Below the navigation bar is the top portion of a biographical page for Septima Poinsette Clark, including her name, portrait, and introductory text.' src="https://github.com/user-attachments/assets/5c8e9cb1-f6f9-411f-9ee1-6e59593c0b87" />
