### PR TITLE
✨ blog: Add exclusion filter, excerpts, and title casing to taxonomies

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -294,7 +294,7 @@ footer #footer-box a:hover {
 }
 
 
-/* ===[ Taxonomy: terms list sort controls ]=== */
+/* ===[ Taxonomy: terms list sort controls (layouts/_default/terms.html) ]=== */
 
 /*
  * Sort toggle and count sit on a single row above the terms list.
@@ -341,4 +341,17 @@ footer #footer-box a:hover {
 
 .terms-sort-btn:hover:not(.active) {
   background-color: #f5f4f0;
+}
+
+
+/* ===[ Taxonomy: Term page excerpts (layouts/_default/term.html) ]=== */
+
+/*
+ * Short text previews shown under each post title on term pages.
+ * Uses a smaller font size and muted color so it doesn't compete
+ * with the title link for visual attention.
+ */
+.term-excerpt {
+  font-size: 0.85rem;
+  line-height: 1.5;
 }

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -106,6 +106,7 @@ params:
     - /toph-hugo-theme/img/septima.jpg
   favicon: /toph-hugo-theme/favicon.ico
   git_repo: https://github.com/justwheel/toph-hugo-theme
+  taxonomy_exclude: ["footer", "projects"]
   # Are you looking for new opportunities? Set hire_me to "true" if you want your LinkedIn to show on the nav bar and
   # for boilerplate text on how to get in touch.
   hire_me: false

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -12,9 +12,11 @@
       .Content            — any custom content from the term's _index.md (if it exists)
       .Pages              — all content pages tagged with this term
       .Title              — the post title; falls back to the filename if no title is set
+      .Data.Singular      — the singular form of the taxonomy name (e.g., "tag", "category")
       .Date               — the publish date of the content page
       .File.BaseFileName  — the filename without extension (used as title fallback)
-      .Data.Singular      — the singular form of the taxonomy name (e.g., "tag", "category")
+      .Params.description — optional front-matter field for a hand-written summary
+      .Summary            — Hugo's auto-generated excerpt (first ~70 words of content)
 */}}
 {{ define "main" }}
 {{- .Content }}
@@ -26,8 +28,9 @@
         {{/*
             Display the post title. If no title is set in front matter,
             fall back to the filename (e.g., "my-first-post" from my-first-post.md).
+            Apply | title for consistent Title Case capitalization.
         */}}
-        <a href="{{ .Permalink }}">{{ .Title | default .File.BaseFileName }}</a>
+        <a href="{{ .Permalink }}">{{ .Title | default .File.BaseFileName | title }}</a>
         {{/*
             Only show the date if the page has one set. Hugo initializes .Date
             to a zero time value when unset, so .Date.IsZero detects that.
@@ -36,6 +39,20 @@
         <small class="text-muted ms-2">
             <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006-01-02" }}</time>
         </small>
+        {{ end }}
+
+        {{/*
+            Excerpt logic — show a short preview of each post's content.
+
+            Priority order:
+              1. Use .Params.description if the author set one in front matter.
+                 This is a hand-crafted summary, so it's always preferred.
+              2. Otherwise, fall back to Hugo's .Summary (first ~70 words).
+        */}}
+        {{ with .Params.description | default .Summary }}
+        <p class="term-excerpt text-muted mb-0 mt-1">
+            {{ . }}
+        </p>
         {{ end }}
     </li>
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -19,9 +19,19 @@
     lets users switch to "most used" order via client-side DOM reordering —
     each <li> carries a data-count attribute that JavaScript reads to re-sort
     without a page reload.
+
+    We also filter out "structural" taxonomy terms (like "footer" and "projects")
+    that the Toph theme uses internally for layout purposes, not for blog content.
+    The exclusion list is configurable via params.taxonomy_exclude in config.yaml.
 */}}
 {{ define "main" }}
 {{- .Content }}
+
+{{/*
+    Load the exclusion list from site config (e.g., ["footer", "projects"]).
+    If no list is configured, default to an empty slice so the range still works.
+*/}}
+{{- $exclude := site.Params.taxonomy_exclude | default slice -}}
 
 {{ if .Pages }}
 {{/*
@@ -54,14 +64,27 @@
 */}}
 <ul class="list-group terms-list" role="list">
 {{ range .Pages.ByTitle }}
+    {{/*
+        Compare the lowercase version of .Title against the exclusion list.
+        Hugo auto-capitalizes taxonomy term titles (e.g., "footer" → "Footer"),
+        so we lowercase before comparing to ensure a reliable match.
+    */}}
+    {{- if not (in $exclude (.Title | lower)) }}
     <li class="list-group-item d-flex justify-content-between align-items-center"
         data-count="{{ .Pages | len }}"
         data-name="{{ .Title | lower }}">
-        <a href="{{ .Permalink }}">{{ .Title }}</a>
+        {{/*
+            Apply | title to ensure consistent Title Case display.
+            Without this, multi-word terms like "civil rights" would render as
+            "Civil rights" (Hugo only capitalizes the first letter by default).
+        */}}
+        <a href="{{ .Permalink }}">{{ .Title | title }}</a>
+        {{/* Badge showing how many posts use this term */}}
         <span class="badge rounded-pill" style="background-color: var(--primary); color: var(--secondary);">
             {{ .Pages | len }}
         </span>
     </li>
+    {{- end }}
 {{ end }}
 </ul>
 


### PR DESCRIPTION
Enhance the default terms and term templates with features needed for blog taxonomy pages:

- Filter structural taxonomy terms (`footer`, `projects`) from the terms list using the configurable `taxonomy_exclude` param
- Add post excerpts on term pages, preferring front matter description with a fallback to Hugo's `.Summary`
- Apply title casing for consistent display of multi-word terms
- Add CSS for term excerpts

These are generic improvements to the `_default` templates that benefit all taxonomies, split out from the taxonomy-specific work (categories grid, tags word cloud) to keep PRs focused.