### PR TITLE
🔧 layouts: Make date display format configurable

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -133,6 +133,12 @@ params:
     # tiktok: ""
     # youtube: ""
 
+  # Human-readable date format used across all templates.
+  # Uses Go time formatting (https://gohugo.io/functions/time/format/).
+  # Default: "2006 January 02" (e.g., "2023 May 09").
+  # Other examples: "January 2, 2006", "02 Jan 2006", "2006-01-02".
+  date_format: "2006 January 02"
+
   # --- layout configuration ---
   # These values control how much content appears in specific page layouts.
   # Defaults are tuned for sites with many categories to keep pages scannable

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -28,7 +28,7 @@
         <a href="{{ .Permalink }}">{{ .Title | default .File.BaseFileName | htmlUnescape }}</a>
         {{ if not .Date.IsZero }}
         <small class="text-muted ms-2">
-            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006 January 02" }}</time>
+            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format (site.Params.date_format | default "2006 January 02") }}</time>
         </small>
         {{ end }}
         {{/*

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -40,7 +40,7 @@
         */}}
         {{ if not .Date.IsZero }}
         <small class="text-muted ms-2">
-            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006 January 02" }}</time>
+            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format (site.Params.date_format | default "2006 January 02") }}</time>
         </small>
         {{ end }}
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -100,7 +100,7 @@
                     <a href="{{ .Permalink }}">{{ .Title | default .File.BaseFileName | htmlUnescape }}</a>
                     <br>
                     <time class="text-muted" datetime="{{ .Date.Format "2006-01-02" }}">
-                        {{- .Date.Format "2006 January 02" -}}
+                        {{- .Date.Format (site.Params.date_format | default "2006 January 02") -}}
                     </time>
                     {{/*
                         Excerpt: prefer hand-written description, fall back to

--- a/layouts/categories/terms.html
+++ b/layouts/categories/terms.html
@@ -118,7 +118,7 @@
                             <a href="{{ .Permalink }}">{{ .Title | default .File.BaseFileName | htmlUnescape | title }}</a>
                             {{ if not .Date.IsZero }}
                             <br>
-                            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006 January 02" }}</time>
+                            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format (site.Params.date_format | default "2006 January 02") }}</time>
                             {{ end }}
                             {{/*
                                 Excerpt for each recent post:

--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -30,7 +30,7 @@
         <li>
             Published
             <time datetime="{{ .Date.Format "2006-01-02" }}">
-                {{- .Date.Format "2006 January 02" -}}
+                {{- .Date.Format (site.Params.date_format | default "2006 January 02") -}}
             </time>
         </li>
         {{/*
@@ -43,7 +43,7 @@
         <li>
             Updated
             <time datetime="{{ .Lastmod.Format "2006-01-02" }}">
-                {{- .Lastmod.Format "2006 January 02" -}}
+                {{- .Lastmod.Format (site.Params.date_format | default "2006 January 02") -}}
             </time>
         </li>
         {{ end }}

--- a/layouts/partials/recent-posts.html
+++ b/layouts/partials/recent-posts.html
@@ -44,7 +44,7 @@
             {{- .Title | htmlUnescape -}}
         </a>
         <time class="recent-featured-date" datetime="{{ .Date.Format "2006-01-02" }}">
-            {{- .Date.Format "2006 January 02" -}}
+            {{- .Date.Format (site.Params.date_format | default "2006 January 02") -}}
         </time>
         <p class="recent-featured-excerpt">
             {{- .Params.description | default (.Plain | htmlUnescape | truncate 250) -}}
@@ -61,7 +61,7 @@
                 {{- .Title | htmlUnescape -}}
             </a>
             <time class="recent-card-date" datetime="{{ .Date.Format "2006-01-02" }}">
-                {{- .Date.Format "2006 January 02" -}}
+                {{- .Date.Format (site.Params.date_format | default "2006 January 02") -}}
             </time>
             <p class="recent-card-excerpt">
                 {{- .Params.description | default (.Plain | htmlUnescape | truncate 140) -}}


### PR DESCRIPTION
Replace hardcoded date format "`2006 January 02`" in all 6 templates with a configurable site parameter (`params.date_format`). Falls back to the current format if not set.

Templates updated: `post-meta.html`, `term.html`, `list.html`, `categories/terms.html`, `blog/list.html`, `recent-posts.html`.

The `datetime` HTML attributes remain as ISO 2006-01-02 — only the human-visible display format is configurable.

Add documented `date_format` parameter to exampleSite config.

Closes #28.