### PR TITLE
🌐 i18n(nav): Localize "social" and "translations" dropdown labels

### DIFF
--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -5,3 +5,7 @@
 
 - misc:
     page_navigation: التنقل بين الصفحات
+
+- nav:
+    social: تواصل
+    translations: لغات

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -38,3 +38,7 @@
     next: Next
     page_navigation: Page navigation
     previous: Previous
+
+- nav:
+    social: social
+    translations: translations

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -29,8 +29,16 @@
       header: Personaliza tu página de inicio
     rounded_profile_image: Imagen de
 
+- hero:
+    about: Acerca de
+    photo: Foto de
+
 - misc:
     logo: "Logotipo de {{ .Title }}"
     next: Próximo
     page_navigation: Navegación de páginas
     previous: Anterior
+
+- nav:
+    social: redes sociales
+    translations: idiomas

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -1,3 +1,11 @@
 ---
+- hero:
+    about: परिचय
+    photo: फ़ोटो
+
 - misc:
     page_navigation: पृष्ठ नेविगेशन
+
+- nav:
+    social: सोशल मीडिया
+    translations: भाषाएँ

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -25,7 +25,7 @@
                 {{ end }}
                 {{- with $.Site.Params.social }}
                 <li class="nav-item dropdown nav-hover-dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" role="button" aria-expanded="false">social</a>
+                    <a class="nav-link dropdown-toggle" href="#" role="button" aria-expanded="false">{{ i18n "nav.social" }}</a>
                     <ul class="dropdown-menu">
                     {{ range $key, $value := . }}
                         {{ with index hugo.Data.social $key }}
@@ -38,7 +38,7 @@
                 {{- if .IsTranslated }}
                     {{ "<!-- language selector -->" | safeHTML }}
                     <li class="nav-item dropdown nav-hover-dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" role="button" aria-expanded="false">translations</a>
+                        <a class="nav-link dropdown-toggle" href="#" role="button" aria-expanded="false">{{ i18n "nav.translations" }}</a>
                         <ul class="dropdown-menu">
                             {{ range .AllTranslations }}
                             <li><a class="dropdown-item{{ if eq .Lang $currentPage.Lang }} active" aria-current="page"{{ else }}"{{ end }} href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>


### PR DESCRIPTION
The nav partial had hardcoded English strings for the "social" and "translations" dropdown labels, breaking the experience for non-English locales. Replace them with `i18n` calls and add the corresponding keys to all four language files.

Also backfills missing `hero.about` and `hero.photo` keys for Spanish and Hindi, which were added for English and Arabic in an earlier change but not propagated to the other locales.

New i18n keys:
- `nav.social`:        social / تواصل / redes sociales / सोशल मीडिया
- `nav.translations`:  translations / لغات / idiomas / भाषाएँ
- `hero.about`:        (es):   Acerca de       (hi): परिचय
- `hero.photo`:        (es):   Foto de         (hi): फ़ोटो