### PR TITLE
🌐🐛 i18n: Replace hardcoded "GitLab" with platform-neutral footer text

### DIFF
--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -1,4 +1,7 @@
 ---
+- footer:
+    find_this_site: الكود المصدري
+
 - hero:
     about: حول
     photo: صورة

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -4,7 +4,11 @@
     header: Page not found
 
 - footer:
-    find_this_site: Find this site on GitLab
+    find_this_site: Source code
+
+- hero:
+    about: About
+    photo: Picture of
 
 - hire_me:
     body: >
@@ -28,10 +32,6 @@
       customize_step3: Configure your web server to automatically redirect home page traffic to a specific page.
       header: Customize your home page
     rounded_profile_image: Picture of
-
-- hero:
-    about: About
-    photo: Picture of
 
 - misc:
     logo: "{{ .Title }} logo"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -4,7 +4,7 @@
     header: Page not found
 
 - footer:
-    find_this_site: Source code
+    find_this_site: source code
 
 - hero:
     about: About

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -4,7 +4,7 @@
     header: "Página no encontrada"
 
 - footer:
-    find_this_site: Código fuente
+    find_this_site: código fuente
 
 - hero:
     about: Acerca de

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -4,7 +4,11 @@
     header: "Página no encontrada"
 
 - footer:
-    find_this_site: Encuentra este sitio en GitLab
+    find_this_site: Código fuente
+
+- hero:
+    about: Acerca de
+    photo: Foto de
 
 - hire_me:
     body: >
@@ -28,10 +32,6 @@
       customize_step3: Configure su servidor web para redirigir automáticamente el tráfico de la página de inicio a una página específica.
       header: Personaliza tu página de inicio
     rounded_profile_image: Imagen de
-
-- hero:
-    about: Acerca de
-    photo: Foto de
 
 - misc:
     logo: "Logotipo de {{ .Title }}"

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -1,4 +1,7 @@
 ---
+- footer:
+    find_this_site: स्रोत कोड
+
 - hero:
     about: परिचय
     photo: फ़ोटो


### PR DESCRIPTION
The `footer.find_this_site` i18n string said "Find this site on GitLab" in English and Spanish, even though `params.git_repo` can point to any hosting platform. Replace with a neutral "Source code" label and add the translation to Arabic and Hindi (which had no footer section and were falling back to the English "GitLab" text).

Sort all four i18n files into consistent alphabetical section order.

Closes #47.