### PR TITLE
♻️ layouts(single): Use standard `.Params.images` for cover image

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,14 +28,17 @@
 
 {{/* --- Cover image (between title and metadata) --- */}}
 {{/*
-    Renders the post's cover image if coverImage is set in front matter.
+    Renders the post's cover image from .Params.images (Hugo's standard
+    convention). Using .Params.images also enables the built-in OpenGraph
+    and Twitter Card templates to use the image for social sharing.
+
     Supports two path formats:
       - Absolute path (e.g., "/img/photo.jpg") — served from static/img/
       - Filename only (e.g., "photo.jpg") — resolved relative to the
         post's content directory
 */}}
-{{ if and $is_blog_post .Params.coverImage }}
-    {{- $src := .Params.coverImage -}}
+{{ if and $is_blog_post .Params.images }}
+    {{- $src := index .Params.images 0 -}}
     {{- $alt := .Title | plainify -}}
     {{- if not (hasPrefix $src "/") -}}
         {{/*
@@ -46,7 +49,7 @@
             URL from the post's directory path.
         */}}
         {{- with .File -}}
-            {{- $src = path.Join "/" (path.Dir .Path) $.Params.coverImage -}}
+            {{- $src = path.Join "/" (path.Dir .Path) $src -}}
         {{- end -}}
     {{- end -}}
     <div class="cover-image">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -32,7 +32,8 @@
     convention). Using .Params.images also enables the built-in OpenGraph
     and Twitter Card templates to use the image for social sharing.
 
-    Supports two path formats:
+    Supports three path formats:
+      - Remote URL (e.g., "https://cdn.example.com/photo.jpg") — used as-is
       - Absolute path (e.g., "/img/photo.jpg") — served from static/img/
       - Filename only (e.g., "photo.jpg") — resolved relative to the
         post's content directory
@@ -40,7 +41,7 @@
 {{ if and $is_blog_post .Params.images }}
     {{- $src := index .Params.images 0 -}}
     {{- $alt := .Title | plainify -}}
-    {{- if not (hasPrefix $src "/") -}}
+    {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
         {{/*
             Non-absolute path — resolve relative to the post's directory.
             Blog images are stored alongside the post files in


### PR DESCRIPTION
Replace the custom `.Params.coverImage` field with Hugo's standard `.Params.images` convention. Hugo's built-in OpenGraph and Twitter Card templates automatically read `.Params.images` for social sharing previews, so this change connects cover images to social metadata without writing any custom OpenGraph template code.

The cover image display logic is unchanged — same path resolution for absolute and relative paths, same visual rendering. Only the frontmatter field name changes from `coverImage` (string) to `images` (array), which content files must adopt.