### PR TITLE
📱 css(post-meta): Stack metadata items vertically on mobile

### DIFF
--- a/assets/css/components/_post-meta.css
+++ b/assets/css/components/_post-meta.css
@@ -75,6 +75,7 @@ main a.post-meta-tag:hover {
 /* On mobile, stack metadata items vertically */
 @media screen and (max-width: 600px) {
   .post-meta-list {
+    align-items: flex-start;
     flex-direction: column;
     gap: 0.35rem;
   }

--- a/assets/css/components/_post-meta.css
+++ b/assets/css/components/_post-meta.css
@@ -74,6 +74,11 @@ main a.post-meta-tag:hover {
 
 /* On mobile, stack metadata items vertically */
 @media screen and (max-width: 600px) {
+  .post-meta-list {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
   .post-meta-list li + li {
     border-inline-start: none;
     padding-inline-start: 0;


### PR DESCRIPTION
On viewports under 600px, the metadata list items (published date, author, reading time, word count) lost their vertical dividers but remained inline with only 0.25rem gap, making them visually run together with no separation. Add `flex-direction: column` and increase the gap so each item sits on its own line.