### PR TITLE
📱 css(global): Replace header media queries with `clamp()`

### DIFF
--- a/assets/css/base/_global.css
+++ b/assets/css/base/_global.css
@@ -54,16 +54,11 @@ h1 {
 
 h2, h4, #toctitle { color: var(--accent-color); }
 
-@media screen and (min-width: 601px) {
-  h1 { font-size: 5em; }
-  h2 { font-size: 40pt; }
-  h3, #toctitle { font-size: 28pt; }
-  h4 { font-size: 22pt;}
-}
-
-@media screen and (max-width: 600px) {
-  h1 { font-size: 16vw; }
-  h2 { font-size: 10vw; }
-  h3, #toctitle { font-size: 8vw; }
-  h4 { font-size: 5vw; }
-}
+/* Fluid heading sizes — scales smoothly across all viewport widths.
+ * clamp(min, preferred, max) avoids the hard jump at 600px that the
+ * previous media-query approach produced. Max values preserve the
+ * original desktop sizes (5em, 40pt, 28pt, 22pt). */
+h1 { font-size: clamp(2rem, 6vw + 0.5rem, 5rem); }
+h2 { font-size: clamp(1.75rem, 4vw + 0.5rem, 3.35rem); }
+h3, #toctitle { font-size: clamp(1.5rem, 3vw + 0.5rem, 2.35rem); }
+h4 { font-size: clamp(1.25rem, 2vw + 0.25rem, 1.85rem); }


### PR DESCRIPTION
Yay fluid scaling!

The heading sizes used two hard breakpoints at 600px — desktop got fixed sizes (5em, 40pt, 28pt, 22pt) and mobile got viewport-relative sizes (16vw, 10vw, 8vw, 5vw). This produced a visible jump between the two and the mobile H1 at 16vw was still 60px on a 375px phone, too large for long titles in a decorative display font.

Replace both media query blocks with single `clamp()` rules per heading level. `clamp(min, preferred, max)` is a CSS function that evaluates the preferred (middle) value at the current viewport width and constrains it between a floor and ceiling. The browser continuously recalculates as the viewport resizes, producing smooth scaling with no breakpoint jumps.

The preferred value uses a `vw + rem` formula (e.g., `6vw + 0.5rem`). The `vw` component scales proportionally with the viewport, while the `rem` offset prevents the font from shrinking too aggressively on narrow screens. For H1 at `clamp(2rem, 6vw + 0.5rem, 5rem)`:

- 320px viewport: 6vw + 0.5rem = 27.2px → clamped to 2rem (32px)
- 768px viewport: 6vw + 0.5rem = 54.1px → used as-is
- 1200px viewport: 6vw + 0.5rem = 80px → clamped to 5rem (80px)

The max values preserve the original desktop heading sizes. The min values ensure readability on the smallest mobile screens.