### PR TITLE
🆕✨ shortcodes: Add `pdf-download` for local PDF files

### DIFF
--- a/assets/css/components/_pdf-download.css
+++ b/assets/css/components/_pdf-download.css
@@ -1,0 +1,91 @@
+/* ===[ PDF download card (layouts/shortcodes/pdf-download.html) ]=== */
+
+.pdf-download {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border-medium);
+  border-radius: 4px;
+  box-shadow: 0 1px 3px var(--shadow-card);
+  transition: box-shadow 0.2s ease, background-color 0.15s ease;
+}
+
+main a.pdf-download {
+  color: inherit;
+  text-decoration: none;
+}
+
+main a.pdf-download:hover {
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 4px 12px var(--shadow-card);
+  background-color: var(--bg-hover);
+}
+
+.pdf-download__icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--primary);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 1.25rem;
+}
+
+.pdf-download__info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.pdf-download__title {
+  font-weight: 600;
+}
+
+.pdf-download__description {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.pdf-download__meta {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.pdf-download__button {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 1rem;
+  background-color: var(--primary);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+@media screen and (max-width: 575.98px) {
+  .pdf-download {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .pdf-download__info {
+    align-items: center;
+  }
+
+  .pdf-download__button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,6 +18,7 @@
 @import './components/_post-meta.css';
 @import './components/_post-nav.css';
 @import './components/_code.css';
+@import './components/_pdf-download.css';
 @import './components/_footer.css';
 
 /* Taxonomy pages */

--- a/layouts/shortcodes/pdf-download.html
+++ b/layouts/shortcodes/pdf-download.html
@@ -1,0 +1,29 @@
+{{- $file := .Get "file" -}}
+{{- $title := .Get "title" -}}
+{{- $description := .Get "description" -}}
+{{- $statPath := printf "static%s" $file -}}
+{{- $stat := os.Stat $statPath -}}
+{{- $bytes := $stat.Size -}}
+{{- $size := "" -}}
+{{- if ge $bytes 1000000000 -}}
+  {{- $size = printf "%.1f GB" (div (float $bytes) 1000000000.0) -}}
+{{- else if ge $bytes 1000000 -}}
+  {{- $size = printf "%.1f MB" (div (float $bytes) 1000000.0) -}}
+{{- else -}}
+  {{- $size = printf "%d KB" (div $bytes 1000) -}}
+{{- end -}}
+<a class="pdf-download" href="{{ $file }}" download>
+  <span class="pdf-download__icon">
+    <i class="bi bi-file-earmark-pdf-fill"></i>
+  </span>
+  <span class="pdf-download__info">
+    <span class="pdf-download__title">{{ $title }}</span>
+    {{- with $description }}
+    <span class="pdf-download__description">{{ . }}</span>
+    {{- end }}
+    <span class="pdf-download__meta">PDF &middot; {{ $size }}</span>
+  </span>
+  <span class="pdf-download__button">
+    <i class="bi bi-download"></i> Download
+  </span>
+</a>

--- a/layouts/shortcodes/pdf-download.html
+++ b/layouts/shortcodes/pdf-download.html
@@ -1,7 +1,7 @@
 {{- $file := .Get "file" -}}
 {{- $title := .Get "title" -}}
 {{- $description := .Get "description" -}}
-{{- $statPath := printf "static%s" $file -}}
+{{- $statPath := path.Join "static" $file -}}
 {{- $stat := os.Stat $statPath -}}
 {{- $bytes := $stat.Size -}}
 {{- $size := "" -}}
@@ -12,7 +12,7 @@
 {{- else -}}
   {{- $size = printf "%d KB" (div $bytes 1000) -}}
 {{- end -}}
-<a class="pdf-download" href="{{ $file }}" download>
+<a class="pdf-download" href="{{ $file | relURL }}" download>
   <span class="pdf-download__icon">
     <i class="bi bi-file-earmark-pdf-fill"></i>
   </span>


### PR DESCRIPTION
Add a reusable shortcode that renders a styled horizontal-bar download card for PDF files hosted in `static/`. The card displays a PDF icon, document title, optional description, auto-computed file size, and a download button. The entire card is a clickable download link.

This is the first shortcode in the Toph theme. It was motivated by bare Markdown links in blog posts that were visually indistinguishable from regular links — making downloads easy to miss. The horizontal bar layout was chosen over a stacked card or minimal accent border because it fits naturally in flowing content without breaking reading rhythm.

File size uses SI units (÷1000) and formats as KB, MB, or GB. The CSS component follows existing theme patterns: BEM class names, CSS custom properties for all colors, and a `main a.pdf-download` selector to override the content area's default link styling. The card stacks vertically on mobile viewports below 576px.

Ref: https://github.com/justwheel/jwheel.org/issues/15