### PR TITLE
✨ layouts(rss): Include cover images in RSS feed items

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -19,7 +19,55 @@
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <guid>{{ .Permalink }}</guid>
-      <description>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</description>
+      {{- with .Params.images }}
+      {{- $src := index . 0 -}}
+      {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
+        {{- with $.File -}}
+          {{- $src = path.Join "/" (path.Dir .Path) $src -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $absUrl := $src -}}
+      {{- if not (findRE "^https?://" $src) -}}
+        {{- $absUrl = $src | absURL -}}
+      {{- end -}}
+      {{- $statPath := "" -}}
+      {{- $trimmed := strings.TrimPrefix "/" $src -}}
+      {{- with os.Stat (path.Join "content" $trimmed) -}}
+        {{- $statPath = path.Join "content" $trimmed -}}
+      {{- else -}}
+        {{- with os.Stat (path.Join "static" $trimmed) -}}
+          {{- $statPath = path.Join "static" $trimmed -}}
+        {{- else -}}
+          {{- with os.Stat (path.Join "assets" $trimmed) -}}
+            {{- $statPath = path.Join "assets" $trimmed -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+      {{- with os.Stat $statPath -}}
+        {{- $ext := path.Ext $src | strings.ToLower -}}
+        {{- $mime := "image/jpeg" -}}
+        {{- if eq $ext ".png" }}{{ $mime = "image/png" -}}
+        {{- else if eq $ext ".gif" }}{{ $mime = "image/gif" -}}
+        {{- else if eq $ext ".svg" }}{{ $mime = "image/svg+xml" -}}
+        {{- else if eq $ext ".webp" }}{{ $mime = "image/webp" -}}
+        {{- end }}
+      <enclosure url="{{ $absUrl }}" length="{{ .Size }}" type="{{ $mime }}" />
+      {{- end }}
+      {{- end }}
+      <description>{{ printf "<![CDATA[" | safeHTML }}
+      {{- with .Params.images -}}
+        {{- $src := index . 0 -}}
+        {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
+          {{- with $.File -}}
+            {{- $src = path.Join "/" (path.Dir .Path) $src -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if not (findRE "^https?://" $src) -}}
+          {{- $src = $src | absURL -}}
+        {{- end -}}
+        <img src="{{ $src }}" alt="{{ $.Title | plainify }}">
+      {{- end -}}
+      {{ .Content }}{{ printf "]]>" | safeHTML }}</description>
     </item>
     {{- end }}
   </channel>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -13,14 +13,16 @@
     <managingEditor>{{ . }}</managingEditor>{{ end }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{- with .OutputFormats.Get "rss" }}<atom:link href="{{ .Permalink }}" rel="self" type="{{ .MediaType }}" />{{ end }}
+    {{- $mimeTypes := dict ".jpg" "image/jpeg" ".jpeg" "image/jpeg" ".png" "image/png" ".gif" "image/gif" ".svg" "image/svg+xml" ".webp" "image/webp" -}}
     {{- range .RegularPages }}
+    {{- $page := . -}}
     {{- $absUrl := "" -}}
     {{- $encLength := 0 -}}
     {{- $encMime := "" -}}
     {{- with .Params.images -}}
       {{- $src := index . 0 -}}
       {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
-        {{- with $.File -}}
+        {{- with $page.File -}}
           {{- $src = path.Join "/" (path.Dir .Path) $src -}}
         {{- end -}}
       {{- end -}}
@@ -37,7 +39,6 @@
         {{- end -}}
         {{- with $fileInfo -}}
           {{- $encLength = .Size -}}
-          {{- $mimeTypes := dict ".jpg" "image/jpeg" ".jpeg" "image/jpeg" ".png" "image/png" ".gif" "image/gif" ".svg" "image/svg+xml" ".webp" "image/webp" -}}
           {{- $encMime = index $mimeTypes (path.Ext $src | strings.ToLower) | default "image/jpeg" -}}
         {{- end -}}
       {{- else -}}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -14,60 +14,49 @@
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{- with .OutputFormats.Get "rss" }}<atom:link href="{{ .Permalink }}" rel="self" type="{{ .MediaType }}" />{{ end }}
     {{- range .RegularPages }}
-    <item>
-      <title>{{ .Title }}</title>
-      <link>{{ .Permalink }}</link>
-      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      <guid>{{ .Permalink }}</guid>
-      {{- with .Params.images }}
+    {{- $absUrl := "" -}}
+    {{- $encLength := 0 -}}
+    {{- $encMime := "" -}}
+    {{- with .Params.images -}}
       {{- $src := index . 0 -}}
       {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
         {{- with $.File -}}
           {{- $src = path.Join "/" (path.Dir .Path) $src -}}
         {{- end -}}
       {{- end -}}
-      {{- $absUrl := $src -}}
       {{- if not (findRE "^https?://" $src) -}}
         {{- $absUrl = $src | absURL -}}
-      {{- end -}}
-      {{- $statPath := "" -}}
-      {{- $trimmed := strings.TrimPrefix "/" $src -}}
-      {{- with os.Stat (path.Join "content" $trimmed) -}}
-        {{- $statPath = path.Join "content" $trimmed -}}
+        {{- $trimmed := strings.TrimPrefix "/" $src -}}
+        {{- $fileInfo := false -}}
+        {{- if fileExists (path.Join "content" $trimmed) -}}
+          {{- $fileInfo = os.Stat (path.Join "content" $trimmed) -}}
+        {{- else if fileExists (path.Join "static" $trimmed) -}}
+          {{- $fileInfo = os.Stat (path.Join "static" $trimmed) -}}
+        {{- else if fileExists (path.Join "assets" $trimmed) -}}
+          {{- $fileInfo = os.Stat (path.Join "assets" $trimmed) -}}
+        {{- end -}}
+        {{- with $fileInfo -}}
+          {{- $encLength = .Size -}}
+          {{- $mimeTypes := dict ".jpg" "image/jpeg" ".jpeg" "image/jpeg" ".png" "image/png" ".gif" "image/gif" ".svg" "image/svg+xml" ".webp" "image/webp" -}}
+          {{- $encMime = index $mimeTypes (path.Ext $src | strings.ToLower) | default "image/jpeg" -}}
+        {{- end -}}
       {{- else -}}
-        {{- with os.Stat (path.Join "static" $trimmed) -}}
-          {{- $statPath = path.Join "static" $trimmed -}}
-        {{- else -}}
-          {{- with os.Stat (path.Join "assets" $trimmed) -}}
-            {{- $statPath = path.Join "assets" $trimmed -}}
-          {{- end -}}
-        {{- end -}}
+        {{- $absUrl = $src -}}
       {{- end -}}
-      {{- with os.Stat $statPath -}}
-        {{- $ext := path.Ext $src | strings.ToLower -}}
-        {{- $mime := "image/jpeg" -}}
-        {{- if eq $ext ".png" }}{{ $mime = "image/png" -}}
-        {{- else if eq $ext ".gif" }}{{ $mime = "image/gif" -}}
-        {{- else if eq $ext ".svg" }}{{ $mime = "image/svg+xml" -}}
-        {{- else if eq $ext ".webp" }}{{ $mime = "image/webp" -}}
-        {{- end }}
-      <enclosure url="{{ $absUrl }}" length="{{ .Size }}" type="{{ $mime }}" />
+    {{- end }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      {{- if $encLength }}
+      <enclosure url="{{ $absUrl }}" length="{{ $encLength }}" type="{{ $encMime }}" />
       {{- end }}
-      {{- end }}
-      <description>{{ printf "<![CDATA[" | safeHTML }}
-      {{- with .Params.images -}}
-        {{- $src := index . 0 -}}
-        {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
-          {{- with $.File -}}
-            {{- $src = path.Join "/" (path.Dir .Path) $src -}}
-          {{- end -}}
-        {{- end -}}
-        {{- if not (findRE "^https?://" $src) -}}
-          {{- $src = $src | absURL -}}
-        {{- end -}}
-        <img src="{{ $src }}" alt="{{ $.Title | plainify }}">
+      <description>{{ "<![CDATA[" | safeHTML }}
+      {{- if $absUrl -}}
+        <img src="{{ $absUrl }}" alt="{{ .Title | plainify }}">
       {{- end -}}
-      {{ .Content }}{{ printf "]]>" | safeHTML }}</description>
+      {{ .Content | safeHTML }}{{ "]]>" | safeHTML }}</description>
     </item>
     {{- end }}
   </channel>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -21,12 +21,8 @@
     {{- $encMime := "" -}}
     {{- with .Params.images -}}
       {{- $src := index . 0 -}}
-      {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
-        {{- with $page.File -}}
-          {{- $src = path.Join "/" (path.Dir .Path) $src -}}
-        {{- end -}}
-      {{- end -}}
-      {{- if not (findRE "^https?://" $src) -}}
+      {{- $src = partial "resolve-image-path.html" (dict "src" $src "file" $page.File) -}}
+      {{- if not (findRE "^(https?:)?//" $src) -}}
         {{- $absUrl = $src | absURL -}}
         {{- $trimmed := strings.TrimPrefix "/" $src -}}
         {{- $fileInfo := false -}}
@@ -42,7 +38,7 @@
           {{- $encMime = index $mimeTypes (path.Ext $src | strings.ToLower) | default "image/jpeg" -}}
         {{- end -}}
       {{- else -}}
-        {{- $absUrl = $src -}}
+        {{- $absUrl = $src | absURL -}}
       {{- end -}}
     {{- end }}
     <item>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -51,7 +51,7 @@
       {{- end }}
       <description>{{ "<![CDATA[" | safeHTML }}
       {{- if $absUrl -}}
-        <img src="{{ $absUrl }}" alt="{{ .Title | plainify }}">
+        <img src="{{ $absUrl }}" alt="{{ .Title | plainify | htmlEscape }}">
       {{- end -}}
       {{ .Content | safeHTML }}{{ "]]>" | safeHTML }}</description>
     </item>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -41,18 +41,7 @@
 {{ if and $is_blog_post .Params.images }}
     {{- $src := index .Params.images 0 -}}
     {{- $alt := .Title | plainify -}}
-    {{- if and (not (hasPrefix $src "/")) (not (findRE "^https?://" $src)) -}}
-        {{/*
-            Non-absolute path — resolve relative to the post's directory.
-            Blog images are stored alongside the post files in
-            content/blog/YYYY/MM/. Since posts are standalone files (not
-            leaf bundles), .Resources is not available. We construct the
-            URL from the post's directory path.
-        */}}
-        {{- with .File -}}
-            {{- $src = path.Join "/" (path.Dir .Path) $src -}}
-        {{- end -}}
-    {{- end -}}
+    {{- $src = partial "resolve-image-path.html" (dict "src" $src "file" .File) -}}
     <div class="cover-image">
         <img src="{{ $src }}" alt="{{ $alt }}" loading="lazy">
     </div>

--- a/layouts/partials/resolve-image-path.html
+++ b/layouts/partials/resolve-image-path.html
@@ -1,0 +1,19 @@
+{{- /*
+    resolve-image-path.html — Resolve a front matter image path
+
+    Handles three formats:
+      - Remote URL (https:// or protocol-relative //) — returned as-is
+      - Absolute path (/img/photo.jpg) — returned as-is
+      - Relative filename (photo.jpg) — resolved relative to the page's
+        content directory using the provided .file context
+
+    Usage:
+      {{ $src = partial "resolve-image-path.html" (dict "src" $src "file" .File) }}
+*/ -}}
+{{- $src := .src -}}
+{{- if and (not (hasPrefix $src "/")) (not (findRE "^(https?:)?//" $src)) -}}
+  {{- with .file -}}
+    {{- $src = path.Join "/" (path.Dir .Path) $src -}}
+  {{- end -}}
+{{- end -}}
+{{- return $src -}}


### PR DESCRIPTION
Blog posts with a cover image (from the images frontmatter field) now include the image in RSS feed entries in two ways: as an inline `<img>` prepended to the HTML content in `CDATA` and as an RSS 2.0 `<enclosure>` element with file size and MIME type. The inline image ensures readers that render HTML see the cover photo, while the enclosure enables readers that use it for thumbnails or media previews.

The file size for `<enclosure>` is calculated via `os.Stat`, trying `content/`, `static/`, and `assets/` directories in order. The MIME type is inferred from the file extension. Posts without a cover image are unaffected.

Path resolution reuses the same three-format logic from `single.html` (remote URL, absolute path, relative filename), with all paths converted to absolute URLs via `absURL` for RSS reader compatibility.