### PR TITLE
🔍 layouts(nav, seo-meta): Add navbar brand and SEO improvements

### DIFF
--- a/assets/css/base/_nav.css
+++ b/assets/css/base/_nav.css
@@ -28,8 +28,11 @@
   font-family: var(--title-font), serif;
   font-size: clamp(0.9rem, 1.5vw + 0.5rem, 1.25rem);
   left: 50%;
+  max-width: calc(100% - 120px);
+  overflow: hidden;
   padding: 0.2em 0.6em;
   position: absolute;
+  text-overflow: ellipsis;
   transform: translateX(-50%);
   white-space: nowrap;
 }

--- a/assets/css/base/_nav.css
+++ b/assets/css/base/_nav.css
@@ -20,22 +20,28 @@
   position: relative;
 }
 
-/* Site title centered in the navbar on all viewports */
+/* Site title in the navbar */
 .navbar-brand {
   background-color: var(--accent-color);
   border-radius: 0.25rem;
   color: var(--secondary);
   font-family: var(--title-font), serif;
   font-size: clamp(0.9rem, 1.5vw + 0.5rem, 1.25rem);
-  left: 50%;
   max-width: calc(100% - 120px);
   overflow: hidden;
   padding: 0.2em 0.6em;
-  position: absolute;
   text-overflow: ellipsis;
-  top: 0;
-  transform: translateX(-50%);
   white-space: nowrap;
+}
+
+/* Center the brand on mobile when the nav is collapsed */
+@media (max-width: 991.98px) {
+  .navbar-brand {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
 }
 
 .navbar-brand:hover,

--- a/assets/css/base/_nav.css
+++ b/assets/css/base/_nav.css
@@ -39,8 +39,8 @@
   .navbar-brand {
     left: 50%;
     position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
+    top: 0.5rem;
+    transform: translateX(-50%);
   }
 }
 

--- a/assets/css/base/_nav.css
+++ b/assets/css/base/_nav.css
@@ -33,6 +33,7 @@
   padding: 0.2em 0.6em;
   position: absolute;
   text-overflow: ellipsis;
+  top: 0;
   transform: translateX(-50%);
   white-space: nowrap;
 }

--- a/assets/css/base/_nav.css
+++ b/assets/css/base/_nav.css
@@ -1,19 +1,67 @@
 /* ===[ Site navigation styling ]=== */
 
 .navbar {
+  --bs-navbar-active-color: var(--secondary);
+  --bs-navbar-brand-color: var(--secondary);
+  --bs-navbar-brand-hover-color: var(--secondary);
   --bs-navbar-color: var(--secondary);
   --bs-navbar-hover-color: var(--secondary);
-  --bs-navbar-active-color: var(--secondary);
   background-color: var(--primary);
   border-bottom: 2px solid var(--accent-color);
   box-shadow: 0 2px 4px var(--shadow-navbar);
-  position: fixed;
-  top: 0;
   left: 0;
+  position: fixed;
   right: 0;
+  top: 0;
   z-index: 100;
 }
 
+.navbar .container-fluid {
+  position: relative;
+}
+
+/* Site title centered in the navbar on all viewports */
+.navbar-brand {
+  background-color: var(--accent-color);
+  border-radius: 0.25rem;
+  color: var(--secondary);
+  font-family: var(--title-font), serif;
+  font-size: clamp(0.9rem, 1.5vw + 0.5rem, 1.25rem);
+  left: 50%;
+  padding: 0.2em 0.6em;
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.navbar-brand:hover,
+.navbar-brand:focus {
+  color: var(--secondary);
+  opacity: 0.85;
+}
+
+/* Nav links */
+.navbar .nav-link,
+.navbar .nav-link:hover,
+.navbar .nav-link:focus {
+  background-color: var(--primary);
+  color: var(--secondary);
+  text-align: center;
+}
+
+.navbar .nav-link.active {
+  background-color: var(--accent-color);
+  color: var(--secondary);
+}
+
+.navbar .nav-link:hover {
+  background-color: var(--nav-hover-bg);
+  text-decoration: underline;
+  text-decoration-color: var(--nav-hover-decoration);
+  text-decoration-style: dotted;
+}
+
+/* Dropdown menus */
 .dropdown-menu {
   background-color: var(--accent-color);
 }
@@ -38,29 +86,9 @@
 /* On mobile (collapsed navbar), show children inline on tap */
 @media (max-width: 991.98px) {
   .nav-hover-dropdown > .dropdown-menu {
-    display: block;
-    position: static;
     border: none;
+    display: block;
     padding-left: 1rem;
+    position: static;
   }
-}
-
-.navbar .nav-link,
-.navbar .nav-link:hover,
-.navbar .nav-link:focus {
-  background-color: var(--primary);
-  color: var(--secondary);
-  text-align: center;
-}
-
-.navbar .nav-link.active {
-  background-color: var(--accent-color);
-  color: var(--secondary);
-}
-
-.navbar .nav-link:hover {
-  background-color: var(--nav-hover-bg);
-  text-decoration: underline;
-  text-decoration-color: var(--nav-hover-decoration);
-  text-decoration-style: dotted;
 }

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,6 +3,7 @@
         <button class="navbar-toggler bg-light" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
+        <a class="navbar-brand" href="{{ "/" | relLangURL }}">{{ site.Title }}</a>
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav">

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,9 +1,9 @@
 <nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
+        <a class="navbar-brand" href="{{ "/" | relLangURL }}">{{ site.Title }}</a>
         <button class="navbar-toggler bg-light" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-        <a class="navbar-brand" href="{{ "/" | relLangURL }}">{{ site.Title }}</a>
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav">

--- a/layouts/partials/seo-meta.html
+++ b/layouts/partials/seo-meta.html
@@ -3,6 +3,11 @@
     <meta name="description" content="{{ . }}" />
     {{- end }}
     <link rel="canonical" href="{{ .Permalink }}" />
+    {{- if .IsTranslated }}
+    {{- range .AllTranslations }}
+    <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+    {{- end }}
+    {{- end }}
     <meta property="og:site_name" content="{{ site.Title }}" />
     <meta name="application-name" content="{{ site.Title }}" />
     {{ with $.Site.Params.social.x }}<meta name="twitter:site" content="@{{ . }}" />{{ end }}

--- a/layouts/partials/seo-meta.html
+++ b/layouts/partials/seo-meta.html
@@ -1,4 +1,4 @@
-    {{- $description := .Description | default .Site.Params.description -}}
+    {{- $description := .Description | default site.Params.description -}}
     {{- with $description }}
     <meta name="description" content="{{ . }}" />
     {{- end }}

--- a/layouts/partials/seo-meta.html
+++ b/layouts/partials/seo-meta.html
@@ -1,3 +1,8 @@
+    {{- $description := .Description | default .Site.Params.description -}}
+    {{- with $description }}
+    <meta name="description" content="{{ . }}" />
+    {{- end }}
+    <link rel="canonical" href="{{ .Permalink }}" />
     <meta property="og:site_name" content="{{ site.Title }}" />
     <meta name="application-name" content="{{ site.Title }}" />
     {{ with $.Site.Params.social.x }}<meta name="twitter:site" content="@{{ . }}" />{{ end }}


### PR DESCRIPTION
The site title is the key identity signal for search engines, but it only appeared in 6 places across the theme — primarily in the `<title>` tag and meta properties. The navbar had zero branding, leaving the site's most visible navigation element without any identity.

Add a centered navbar-brand element that displays `site.Title` on every page and every viewport. The brand uses the title font with fluid `clamp()` sizing and an accent-color background pill for contrast with decorative fonts like Bungee Shade. Absolute centering keeps the brand independent of the toggler and nav link layout.

Add `<meta name="description">` with per-page `.Description` fallback to `site.Params.description`. Google uses this as the primary source for search result snippets. Hugo's built-in OpenGraph template already generates `og:description`, but the standard meta tag is what Google reads for snippet display.

Add `<link rel="canonical">` using `.Permalink`. This is critical for the multilingual site (with four languages) to prevent Google from indexing translated pages as duplicate content.

Also, since I was already working on the navbar feature, I reorganized `_nav.css` with alphabetically sorted properties, logical section grouping, and section comments for readability.