### PR TITLE
🔍 layouts(head, seo-meta): Add homepage tagline, better structured data

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
     {{ hugo.Generator }}
 
     {{ if .IsHome }}
-    <title>{{ .Site.Title }}</title>
+    <title>{{ .Site.Title }}{{ with .Site.Params.biography.tagline }} — {{ . }}{{ end }}</title>
     {{ else }}
     <title>{{ .Title }} | {{ .Site.Title }}</title>
     {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,9 +5,9 @@
     {{ hugo.Generator }}
 
     {{ if .IsHome }}
-    <title>{{ .Site.Title }}{{ with .Site.Params.biography.tagline }} — {{ . }}{{ end }}</title>
+    <title>{{ site.Title }}{{ with site.Params.biography.tagline }} — {{ . }}{{ end }}</title>
     {{ else }}
-    <title>{{ .Title }} | {{ .Site.Title }}</title>
+    <title>{{ .Title }} | {{ site.Title }}</title>
     {{ end }}
 
     {{ "<!-- Theme SEO template -->" | safeHTML }}

--- a/layouts/partials/seo-meta.html
+++ b/layouts/partials/seo-meta.html
@@ -11,20 +11,35 @@
     <meta property="og:site_name" content="{{ site.Title }}" />
     <meta name="application-name" content="{{ site.Title }}" />
     {{ with $.Site.Params.social.x }}<meta name="twitter:site" content="@{{ . }}" />{{ end }}
-        
-    {{ if (isset .Params "author") }}
-    <meta name="author" content="{{ .Param "author" }}" />
-    <meta property="article:author" content="{{ .Param "author" }}" />
-    {{ else }}
-    <meta name="author" content="{{ $.Site.Params.biography.name }}" />
-    <meta property="article:author" content="{{ $.Site.Params.biography.name }}" />
-    {{ end }}
 
-    {{ if (isset .Params "tags") }}
+    {{- $exclude := site.Params.taxonomy_exclude | default slice -}}
+    {{- $is_structural_by_category := and .Params.categories (gt (len (intersect $exclude .Params.categories)) 0) -}}
+    {{- $is_structural := or (.Params.hide_sitemap | default false) $is_structural_by_category -}}
+    {{- $is_blog_post := and (not .Date.IsZero) (not $is_structural) -}}
+    {{- $author := .Param "author" | default $.Site.Params.biography.name }}
+
+    <meta name="author" content="{{ $author }}" />
+    {{- if $is_blog_post }}
+    <meta property="article:author" content="{{ $author }}" />
+    {{- end }}
+
+    {{- if and $is_blog_post (isset .Params "tags") }}
         {{- range .Params.tags }}
-        <meta property="article:tag" content="{{ . }}" />
+    <meta property="article:tag" content="{{ . }}" />
         {{- end }}
-    {{ end}}
+    {{- end }}
+
+    {{- if .IsHome }}
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "{{ site.Title }}",
+        "url": {{ printf "%s" site.BaseURL }},
+        "description": "{{ site.Params.description }}"
+    }
+    </script>
+    {{- end }}
 
     <script type="application/ld+json">
     {
@@ -59,3 +74,34 @@
         ]
     }
     </script>
+
+    {{- if $is_blog_post }}
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "{{ .Title }}",
+        "datePublished": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
+        "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}",
+        "author": {
+            "@type": "Person",
+            "name": "{{ $author }}",
+            "url": {{ printf "%s" site.BaseURL }}
+        },
+        "publisher": {
+            "@type": "Person",
+            "name": "{{ $.Site.Params.biography.name }}"
+        },
+        {{- with $description }}
+        "description": "{{ . }}",
+        {{- end }}
+        {{- with .Params.images }}
+        "image": "{{ index . 0 | absURL }}",
+        {{- end }}
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "{{ .Permalink }}"
+        }
+    }
+    </script>
+    {{- end }}

--- a/layouts/partials/seo-meta.html
+++ b/layouts/partials/seo-meta.html
@@ -10,13 +10,13 @@
     {{- end }}
     <meta property="og:site_name" content="{{ site.Title }}" />
     <meta name="application-name" content="{{ site.Title }}" />
-    {{ with $.Site.Params.social.x }}<meta name="twitter:site" content="@{{ . }}" />{{ end }}
+    {{ with site.Params.social.x }}<meta name="twitter:site" content="@{{ . }}" />{{ end }}
 
     {{- $exclude := site.Params.taxonomy_exclude | default slice -}}
     {{- $is_structural_by_category := and .Params.categories (gt (len (intersect $exclude .Params.categories)) 0) -}}
     {{- $is_structural := or (.Params.hide_sitemap | default false) $is_structural_by_category -}}
     {{- $is_blog_post := and (not .Date.IsZero) (not $is_structural) -}}
-    {{- $author := .Param "author" | default $.Site.Params.biography.name }}
+    {{- $author := .Param "author" | default site.Params.biography.name }}
 
     <meta name="author" content="{{ $author }}" />
     {{- if $is_blog_post }}
@@ -34,44 +34,31 @@
     {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "name": "{{ site.Title }}",
-        "url": {{ printf "%s" site.BaseURL }},
-        "description": "{{ site.Params.description }}"
+        "name": {{ site.Title | jsonify | safeJS }},
+        "url": {{ site.BaseURL | jsonify | safeJS }},
+        "description": {{ site.Params.description | jsonify | safeJS }}
     }
     </script>
     {{- end }}
 
+    {{- $sameAs := slice -}}
+    {{- range $key, $value := site.Params.social -}}
+        {{- with index hugo.Data.social $key -}}
+            {{- $sameAs = $sameAs | append (printf .url $value) -}}
+        {{- end -}}
+    {{- end }}
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Person",
-        "name": "{{ $.Site.Params.biography.name }}",
-        "familyName": "{{ index (findRE "(\\w|[-])+$" $.Site.Params.biography.name) 0 }}",
-        "gender": "{{ $.Site.Params.biography.gender }}",
-        "image": {{ printf "%s" (index $.Site.Params.images 0) }},
-        "email": "mailto:{{ $.Site.Params.biography.email }}",
-        "url": {{ printf "%s" site.BaseURL }},
-        "sameAs": [
-            {{- $sameAs := slice -}}
-            {{- range $key, $value := $.Site.Params.social -}}
-                {{- with index hugo.Data.social $key -}}
-                    {{- $sameAs = $sameAs | append (printf .url $value) -}}
-                {{- end -}}
-            {{- end -}}
-            {{- range $index, $url := $sameAs }}
-            "{{ $url }}"{{ if ne (add $index 1) (len $sameAs) }},{{ end }}
-            {{- end }}
-        ],
-        "knowsAbout": [
-            {{- $len_knowsAbout := len $.Site.Params.biography.knows_about }}
-            {{- range $index, $knowsAbout := $.Site.Params.biography.knows_about }}
-                {{- if ne (add $index 1) $len_knowsAbout }}
-            {{ . }},
-                {{- else }}
-            {{ . }}
-                {{- end }}
-            {{- end }}
-        ]
+        "name": {{ site.Params.biography.name | jsonify | safeJS }},
+        "familyName": {{ index (findRE "(\\w|[-])+$" site.Params.biography.name) 0 | jsonify | safeJS }},
+        "gender": {{ site.Params.biography.gender | jsonify | safeJS }},
+        "image": {{ index site.Params.images 0 | jsonify | safeJS }},
+        "email": {{ printf "mailto:%s" site.Params.biography.email | jsonify | safeJS }},
+        "url": {{ site.BaseURL | jsonify | safeJS }},
+        "sameAs": {{ $sameAs | jsonify | safeJS }},
+        "knowsAbout": {{ site.Params.biography.knows_about | jsonify | safeJS }}
     }
     </script>
 
@@ -80,27 +67,28 @@
     {
         "@context": "https://schema.org",
         "@type": "Article",
-        "headline": "{{ .Title }}",
-        "datePublished": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
-        "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}",
+        "headline": {{ .Title | jsonify | safeJS }},
+        "datePublished": {{ .Date.Format "2006-01-02T15:04:05-07:00" | jsonify | safeJS }},
+        "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | jsonify | safeJS }},
         "author": {
             "@type": "Person",
-            "name": "{{ $author }}",
-            "url": {{ printf "%s" site.BaseURL }}
+            "name": {{ $author | jsonify | safeJS }},
+            "url": {{ site.BaseURL | jsonify | safeJS }}
         },
         "publisher": {
             "@type": "Person",
-            "name": "{{ $.Site.Params.biography.name }}"
+            "name": {{ site.Params.biography.name | jsonify | safeJS }}
         },
         {{- with $description }}
-        "description": "{{ . }}",
+        "description": {{ . | jsonify | safeJS }},
         {{- end }}
         {{- with .Params.images }}
-        "image": "{{ index . 0 | absURL }}",
+        {{- $img := index . 0 }}
+        "image": {{ (cond (urls.Parse $img).IsAbs $img ($img | absURL)) | jsonify | safeJS }},
         {{- end }}
         "mainEntityOfPage": {
             "@type": "WebPage",
-            "@id": "{{ .Permalink }}"
+            "@id": {{ .Permalink | jsonify | safeJS }}
         }
     }
     </script>

--- a/layouts/partials/seo-meta.html
+++ b/layouts/partials/seo-meta.html
@@ -84,7 +84,9 @@
         {{- end }}
         {{- with .Params.images }}
         {{- $img := index . 0 }}
+        {{- if $img }}
         "image": {{ (cond (urls.Parse $img).IsAbs $img ($img | absURL)) | jsonify | safeJS }},
+        {{- end }}
         {{- end }}
         "mainEntityOfPage": {
             "@type": "WebPage",


### PR DESCRIPTION
The homepage `<title>` was just "Justin Wheeler" for my personal website — a bare name that gives search engines no context about the site. Appending the tagline produces "Justin Wheeler — Building the human infrastructure of open source," which associates the name with descriptive keywords and improves click-through rates in search results. The name comes first so it survives Google's ~60-char truncation. The tagline is guarded with `{{ with }}` so sites without a tagline degrade gracefully.

Add Article JSON-LD on blog posts with headline, dates, author, publisher, description, image, and mainEntityOfPage. Google uses Article schema for rich results and news carousels. Use @type "Article" rather than "BlogPosting" — Google treats them identically, and Article is more generic for a reusable theme.

Add WebSite JSON-LD on the homepage with name, URL, and description. This helps search engines understand the site as a whole entity rather than a collection of unrelated pages.

Guard `article:author` and `article:tag` OpenGraph meta properties to blog posts only. These were previously rendered on every page including the homepage and section pages, which is semantically incorrect — only article pages have authors and tags in the OpenGraph sense.

Also refactor the author meta tag logic to use a single `$author` variable with a fallback chain, replacing the duplicated if/else block.