### PR TITLE
✨ layouts, css, docs: Add tweet-archive shortcode and standalone pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ baseof.html          HTML skeleton: head, nav, header, <main>, footer
     term.html        Fallback single term page with pagination
   team/
     list.html        Team section list page with card grid
+  tweets/
+    single.html      Standalone archived tweet page with full-width card
   blog/
     list.html        Blog archive with year/month Bootstrap accordion
   categories/
@@ -126,6 +128,7 @@ assets/css/
     _code.css                     Code block borders
     _pdf-download.css             PDF download shortcode card
     _team.css                     Team member card grid
+    _tweet-archive.css            Archived tweet card, image grid, lightbox modal
     _footer.css                   Footer badges and footer-box
   taxonomy/
     _terms-controls.css           Sort toggle controls
@@ -167,6 +170,69 @@ Blog features (post-meta, post-nav, ToC) only render for blog posts.
 ### Shortcodes
 
 - `pdf-download.html` — Styled download card for local PDF files with auto-computed file size via `os.Stat`. Parameters: `file` (path in `static/`), `title`, optional `description`. CSS in `assets/css/components/_pdf-download.css`.
+- `tweet-archive.html` — Embeds an archived tweet from the local content archive. Looks up a tweet content page by its `tweet_id` front matter param and renders a styled card with author info, tweet text, image grid, and a link to the standalone archived tweet page. Clicking any image opens a full-screen Bootstrap modal carousel that starts on the clicked image. CSS in `assets/css/components/_tweet-archive.css`.
+
+### Tweet archive
+
+Toph includes a self-hosted tweet archive system for preserving tweets from deleted or inaccessible accounts.
+Each archived tweet is a Hugo page bundle in the site's `content/tweets/<tweet-id>/` directory with images stored alongside the `index.md` file.
+
+#### Content model
+
+Tweet page bundles use the following front matter:
+
+```yaml
+title: "Archived Tweet — @mention1 #hashtag1"
+date: 2020-01-31T13:53:32+00:00
+tweet_id: "1223242916988096512"
+author: "username"
+author_name: "Display Name"
+categories: ["tweets"]
+```
+
+- `tweet_id` (required): The original tweet ID. The `tweet-archive` shortcode uses this to look up the content page.
+- `author`: The Twitter/X handle (without @).
+- `author_name`: Display name shown in the card header. Falls back to `site.Params.biography.name`.
+- `avatar`: Optional profile photo path. Falls back to `site.Params.images[0]` (the site logo).
+- `title`: Should include "Archived Tweet" plus @mentions and #hashtags from the tweet text, for SEO indexing. No `<a>` links — plain text only.
+- Tweet pages should NOT use `hide_sitemap: true` — they are designed to be indexed by search engines.
+
+Tweet body text goes after the front matter as standard Markdown content.
+@mentions should be linked as `[@handle](https://x.com/handle)` and #hashtags as `[#tag](https://x.com/hashtag/tag)`.
+Images are stored as `photo1.jpg`, `photo2.jpg`, etc. in the page bundle directory.
+
+#### Layout
+
+- `layouts/tweets/single.html` — Standalone tweet page using the full viewport width. Renders the same card component as the shortcode but without the "View archived tweet" link.
+- The shortcode renders a centered 550px-max card within blog post content.
+
+#### Image grid behavior
+
+The image grid adapts to the number of photos:
+- 1 photo: Full-width, natural aspect ratio
+- 2 photos: Side-by-side, equal width
+- 3 photos: First photo full-width on top, two smaller photos side-by-side below
+- 4 photos: 2×2 grid
+
+Clicking any image opens a Bootstrap modal carousel lightbox starting on the clicked photo.
+
+#### Shortcode usage
+
+```
+{{</* tweet-archive id="1223242916988096512" */>}}
+```
+
+The `id` parameter must match a content page's `tweet_id` front matter. If no matching page is found, Hugo will error at build time.
+
+#### Accessibility
+
+- Card uses `<figure>` with `role="figure"` and `aria-label`
+- Tweet text uses `<blockquote cite="">` for semantic accuracy
+- Footer uses `<figcaption>`
+- Each image button has a descriptive `aria-label` ("View photo 1 of 4 in full screen")
+- Modal has `aria-label` for screen readers, close button has descriptive label
+- Image buttons have `:focus-visible` outline for keyboard navigation
+- `prefers-reduced-motion` disables hover transitions
 
 ### i18n
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Toph: a lightweight, responsive theme for a biography site, for use with [Hugo](
   - [Team profiles](#team-profiles)
   - [Dynamic footer badges](#dynamic-footer-badges)
   - [Blogging](#blogging)
-- [Shortcodes](#shortcodes) for rich content embeds
+- [Shortcodes](#shortcodes) for rich content embeds (PDF download, [tweet archive](#tweet-archive))
 - [Modular CSS architecture](#css-architecture) with customizable color palette
 - Navbar brand with site title (responsive, centered on mobile)
 - RSS feeds at `/rss/` with site name in titles and autodiscovery in `<head>`
@@ -373,6 +373,63 @@ File size is computed at build time from the file in `static/` and displayed in 
 - 1 MB to 999 MB: one decimal MB (e.g., "2.3 MB")
 - 1 GB and above: one decimal GB (e.g., "1.5 GB")
 
+#### Tweet archive
+
+The `tweet-archive` shortcode embeds a self-hosted archived tweet as a styled card.
+Each archived tweet is a Hugo page bundle with its own dedicated URL, images, and metadata — no external dependencies or JavaScript embeds from Twitter/X.
+
+This is designed for preserving tweets from deleted or inaccessible accounts while maintaining full control over the content and SEO.
+
+##### Features
+
+- **Styled card** with author avatar, display name, handle, and "Archived" badge
+- **Image grid** that adapts to the number of photos (1: full-width natural aspect ratio, 2: side-by-side, 3: one full-width + two side-by-side, 4: 2×2 grid)
+- **Lightbox carousel** — clicking any image opens a full-screen Bootstrap modal carousel starting on the clicked photo
+- **Linked @mentions and #hashtags** pointing to their canonical x.com URLs
+- **Standalone pages** — each tweet has its own URL at `/tweets/<tweet-id>/` for direct linking
+- **SEO-optimized** — tweet pages are indexed in sitemaps with titles containing "Archived Tweet" plus @mentions and #hashtags
+- **Accessible** — semantic `<figure>`/`<blockquote>`/`<figcaption>` markup, keyboard-navigable image buttons with `:focus-visible`, descriptive `aria-label` attributes, and `prefers-reduced-motion` support
+
+##### Content model
+
+Each archived tweet lives in `content/tweets/<tweet-id>/` as a Hugo page bundle:
+
+```
+content/tweets/1223242916988096512/
+  index.md      Front matter + tweet text as Markdown
+  photo1.jpg    Attached images (if any)
+  photo2.jpg
+```
+
+Front matter:
+
+```yaml
+---
+title: "Archived Tweet — @mbbroberg #metrics"
+date: 2020-01-31T13:53:32+00:00
+tweet_id: "1223242916988096512"
+author: "jflory7"
+author_name: "Justin Wheeler"
+categories: ["tweets"]
+---
+```
+
+Tweet body uses standard Markdown.
+@mentions are linked as `[@handle](https://x.com/handle)` and #hashtags as `[#tag](https://x.com/hashtag/tag)`.
+
+##### Usage
+
+```markdown
+{{< tweet-archive id="1223242916988096512" >}}
+```
+
+The `id` parameter must match a content page's `tweet_id` front matter field.
+
+##### Avatar fallback
+
+The card displays the author's profile photo from the `avatar` front matter field.
+If not set, it falls back to the site's default image (`params.images[0]`).
+
 ### CSS architecture
 
 Toph uses Hugo's `css.Build` function to bundle modular CSS files into a single stylesheet at build time.
@@ -382,7 +439,7 @@ The source CSS is organized under `assets/css/` in four directories:
 assets/css/
   main.css                 @import entrypoint (no rules, only imports)
   base/                    Variables, global styles, navbar, main content area
-  components/              Cover image, hero, PDF download, team card grid, post metadata, post nav, code blocks, footer
+  components/              Cover image, hero, PDF download, tweet archive, team card grid, post metadata, post nav, code blocks, footer
   taxonomy/                Sort controls, term excerpts, categories grid, tags word cloud
   blog/                    Recent posts, blog archive accordion
 ```

--- a/assets/css/base/_content.css
+++ b/assets/css/base/_content.css
@@ -1,5 +1,11 @@
 /* ===[ Main body styling ]=== */
 
+/* Break long unbreakable strings (URLs, hashtags, etc.) on small viewports */
+main {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 /* Darken main links further to guarantee 4.5:1 contrast */
 main a {
   color: var(--text-link);

--- a/assets/css/base/_content.css
+++ b/assets/css/base/_content.css
@@ -3,7 +3,6 @@
 /* Break long unbreakable strings (URLs, hashtags, etc.) on small viewports */
 main {
   overflow-wrap: break-word;
-  word-break: break-word;
 }
 
 /* Darken main links further to guarantee 4.5:1 contrast */

--- a/assets/css/base/_global.css
+++ b/assets/css/base/_global.css
@@ -51,7 +51,6 @@ h1 {
   overflow-wrap: break-word;
   padding-bottom: 3rem;
   padding-top: 7rem;
-  word-break: break-word;
 }
 
 h2, h4, #toctitle { color: var(--accent-color); }

--- a/assets/css/base/_global.css
+++ b/assets/css/base/_global.css
@@ -48,8 +48,10 @@ h2, h3, h4, #toctitle { font-family: var(--header-font), serif; }
 
 h1 {
   color: var(--primary);
+  overflow-wrap: break-word;
   padding-bottom: 3rem;
   padding-top: 7rem;
+  word-break: break-word;
 }
 
 h2, h4, #toctitle { color: var(--accent-color); }

--- a/assets/css/components/_tweet-archive.css
+++ b/assets/css/components/_tweet-archive.css
@@ -1,7 +1,7 @@
 /* ===[ Archived tweet card ]=== */
 
 .tweet-archive {
-  background-color: #fff;
+  background-color: var(--bg-white);
   border: 1px solid var(--border-card);
   border-left: 4px solid var(--accent-color);
   border-radius: 0.5rem;
@@ -168,7 +168,7 @@
 
 /* Lightbox modal */
 .tweet-archive-modal .modal-content {
-  background-color: rgba(0, 0, 0, 0.95);
+  background-color: var(--bg-modal-overlay);
   border: none;
 }
 

--- a/assets/css/components/_tweet-archive.css
+++ b/assets/css/components/_tweet-archive.css
@@ -1,0 +1,196 @@
+/* ===[ Archived tweet card ]=== */
+
+.tweet-archive {
+  background-color: #fff;
+  border: 1px solid var(--border-card);
+  border-left: 4px solid var(--accent-color);
+  border-radius: 0.5rem;
+  margin: 1.5rem auto;
+  max-width: 550px;
+  overflow: hidden;
+}
+
+.tweet-archive-body {
+  padding: 1rem 1.25rem;
+}
+
+.tweet-archive-header {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.tweet-archive-avatar {
+  border-radius: 50%;
+  flex-shrink: 0;
+  height: 2.25rem;
+  object-fit: cover;
+  width: 2.25rem;
+}
+
+.tweet-archive-author {
+  flex-grow: 1;
+  line-height: 1.3;
+}
+
+.tweet-archive-name {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.tweet-archive-handle {
+  color: var(--text-muted);
+  display: block;
+  font-size: 0.8rem;
+}
+
+.tweet-archive-badge {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+/* Tweet text uses blockquote for semantic accuracy */
+.tweet-archive-text {
+  border: none;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  margin: 0 0 0.75rem;
+  padding: 0;
+}
+
+.tweet-archive-text p {
+  margin-bottom: 0.5em;
+}
+
+.tweet-archive-text p:last-child {
+  margin-bottom: 0;
+}
+
+/* Image grid */
+.tweet-archive-images {
+  border-radius: 0.375rem;
+  display: grid;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.tweet-archive-images.grid-1 {
+  grid-template-columns: 1fr;
+}
+
+.tweet-archive-images.grid-1 .tweet-archive-image-btn img {
+  max-height: none;
+  object-fit: contain;
+}
+
+.tweet-archive-images.grid-2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+.tweet-archive-images.grid-3 {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+}
+
+.tweet-archive-images.grid-3 .tweet-archive-image-btn:first-child {
+  grid-column: 1 / 3;
+}
+
+.tweet-archive-images.grid-4 {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+
+.tweet-archive-image-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: block;
+  overflow: hidden;
+  padding: 0;
+}
+
+.tweet-archive-image-btn:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: -3px;
+}
+
+.tweet-archive-image-btn img {
+  height: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  transition: opacity 0.15s ease;
+  width: 100%;
+}
+
+.tweet-archive-image-btn:hover img {
+  opacity: 0.85;
+}
+
+/* Footer */
+.tweet-archive-footer {
+  align-items: center;
+  border: none;
+  border-top: 1px solid var(--border-card);
+  display: flex;
+  font-style: normal;
+  justify-content: space-between;
+  padding: 0.6rem 1.25rem;
+}
+
+.tweet-archive-date {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.tweet-archive-link {
+  color: var(--accent-color);
+  font-size: 0.8rem;
+  text-decoration: none;
+}
+
+.tweet-archive-link:hover {
+  text-decoration: underline;
+}
+
+/* Standalone tweet page — full viewport width */
+.tweet-archive.standalone {
+  max-width: 100%;
+}
+
+.tweet-archive.standalone .tweet-archive-image-btn img {
+  max-height: 400px;
+}
+
+/* Lightbox modal */
+.tweet-archive-modal .modal-content {
+  background-color: rgba(0, 0, 0, 0.95);
+  border: none;
+}
+
+.tweet-archive-modal .modal-header {
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 10;
+}
+
+.tweet-archive-modal .carousel-item img {
+  max-height: 85vh;
+  object-fit: contain;
+}
+
+.tweet-archive-modal .carousel-indicators {
+  margin-bottom: 0.5rem;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .tweet-archive-image-btn img {
+    transition: none;
+  }
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -20,6 +20,7 @@
 @import './components/_code.css';
 @import './components/_pdf-download.css';
 @import './components/_team.css';
+@import './components/_tweet-archive.css';
 @import './components/_footer.css';
 
 /* Taxonomy pages */

--- a/data/style.yaml
+++ b/data/style.yaml
@@ -34,6 +34,7 @@ bg:
   hover: "#f5f4f0"
   card-hover: "#f5f0fa"
   card-active: "#ece4f4"
+  modal-overlay: "rgba(0, 0, 0, 0.95)"
 
 nav:
   hover-bg: royalblue

--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -17,3 +17,14 @@
 - nav:
     social: تواصل
     translations: لغات
+
+- tweet_archive:
+    archived: مؤرشف
+    archived_label: تم أرشفة هذا التغريدة
+    close_viewer: إغلاق عارض الصور
+    next_photo: الصورة التالية
+    photo_label: صورة
+    previous_photo: الصورة السابقة
+    view_archived_tweet: عرض التغريدة المؤرشفة
+    view_photo: "عرض الصورة %d من %d بملء الشاشة"
+    viewer_label: عارض صور التغريدة

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -43,3 +43,14 @@
 - nav:
     social: social
     translations: translations
+
+- tweet_archive:
+    archived: Archived
+    archived_label: This tweet has been archived
+    close_viewer: Close photo viewer
+    next_photo: Next photo
+    photo_label: Photo
+    previous_photo: Previous photo
+    view_archived_tweet: View archived tweet
+    view_photo: "View photo %d of %d in full screen"
+    viewer_label: Tweet photo viewer

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -43,3 +43,14 @@
 - nav:
     social: redes sociales
     translations: idiomas
+
+- tweet_archive:
+    archived: Archivado
+    archived_label: Este tweet ha sido archivado
+    close_viewer: Cerrar visor de fotos
+    next_photo: Siguiente foto
+    photo_label: Foto
+    previous_photo: Foto anterior
+    view_archived_tweet: Ver tweet archivado
+    view_photo: "Ver foto %d de %d en pantalla completa"
+    viewer_label: Visor de fotos del tweet

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -26,5 +26,5 @@
     photo_label: फ़ोटो
     previous_photo: पिछली फ़ोटो
     view_archived_tweet: संग्रहीत ट्वीट देखें
-    view_photo: "फ़ोटो %d का %d पूर्ण स्क्रीन में देखें"
+    view_photo: "फ़ोटो %d में से %d पूर्ण स्क्रीन में देखें"
     viewer_label: ट्वीट फ़ोटो दर्शक

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -17,3 +17,14 @@
 - nav:
     social: सोशल मीडिया
     translations: भाषाएँ
+
+- tweet_archive:
+    archived: संग्रहीत
+    archived_label: यह ट्वीट संग्रहीत किया गया है
+    close_viewer: फ़ोटो दर्शक बंद करें
+    next_photo: अगली फ़ोटो
+    photo_label: फ़ोटो
+    previous_photo: पिछली फ़ोटो
+    view_archived_tweet: संग्रहीत ट्वीट देखें
+    view_photo: "फ़ोटो %d का %d पूर्ण स्क्रीन में देखें"
+    viewer_label: ट्वीट फ़ोटो दर्शक

--- a/layouts/shortcodes/tweet-archive.html
+++ b/layouts/shortcodes/tweet-archive.html
@@ -8,7 +8,7 @@
 {{- $author := $tweet.Params.author | default "unknown" -}}
 {{- $authorName := $tweet.Params.author_name | default site.Params.biography.name -}}
 {{- $avatar := $tweet.Params.avatar -}}
-{{- if not $avatar }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
+{{- if $avatar }}{{ $avatar = partial "resolve-image-path.html" (dict "src" $avatar "file" $tweet.File) }}{{ else }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
 {{- $date := $tweet.Date -}}
 {{- $images := $tweet.Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
 {{- $imageCount := len $images -}}
@@ -37,7 +37,7 @@
         {{- end }}
     </div>
     <figcaption class="tweet-archive-footer">
-        <time class="tweet-archive-date" datetime="{{ $date.Format "2006-01-02T15:04:05Z07:00" }}">{{ $date.Format "January 2, 2006 · 15:04 UTC" }}</time>
+        <time class="tweet-archive-date" datetime="{{ $date.Format "2006-01-02T15:04:05Z07:00" }}">{{ time.Format "January 2, 2006 · 15:04" $date }} UTC</time>
         <a href="{{ $tweet.RelPermalink }}" class="tweet-archive-link">{{ i18n "tweet_archive.view_archived_tweet" }} <i class="bi bi-arrow-right" aria-hidden="true"></i></a>
     </figcaption>
 </figure>
@@ -78,11 +78,13 @@
     </div>
 </div>
 <script>
-document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
-    var trigger = e.relatedTarget;
-    var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
-    var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
-    carousel.to(parseInt(slide, 10));
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
+        var trigger = e.relatedTarget;
+        var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
+        var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
+        carousel.to(parseInt(slide, 10));
+    });
 });
 </script>
 {{- end }}

--- a/layouts/shortcodes/tweet-archive.html
+++ b/layouts/shortcodes/tweet-archive.html
@@ -10,13 +10,17 @@
 {{- $avatar := $tweet.Params.avatar -}}
 {{- if $avatar }}{{ $avatar = partial "resolve-image-path.html" (dict "src" $avatar "file" $tweet.File) }}{{ else }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
 {{- $date := $tweet.Date -}}
-{{- $images := $tweet.Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
+{{- $allImages := $tweet.Resources.ByType "image" -}}
+{{- $images := slice -}}
+{{- range $allImages }}{{ if not (strings.HasPrefix .Name "avatar") }}{{ $images = $images | append . }}{{ end }}{{ end -}}
 {{- $imageCount := len $images -}}
 {{- $modalId := printf "tweet-modal-%s" $id -}}
 <figure class="tweet-archive" role="figure" aria-label="Archived tweet by @{{ $author }}">
     <div class="tweet-archive-body">
         <div class="tweet-archive-header">
-            <img class="tweet-archive-avatar" src="{{ $avatar }}" alt="" aria-hidden="true">
+            {{- with $avatar }}
+            <img class="tweet-archive-avatar" src="{{ . }}" alt="{{ $authorName }} avatar">
+            {{- end }}
             <div class="tweet-archive-author">
                 <span class="tweet-archive-name">{{ $authorName }}</span>
                 <span class="tweet-archive-handle">@{{ $author }}</span>
@@ -77,15 +81,19 @@
         </div>
     </div>
 </div>
+{{- if not (.Page.Store.Get "tweet-archive-script") }}{{ .Page.Store.Set "tweet-archive-script" true }}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
-        var trigger = e.relatedTarget;
-        var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
-        var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
+    document.addEventListener('show.bs.modal', function(e) {
+        if (!e.target.classList.contains('tweet-archive-modal')) return;
+        const trigger = e.relatedTarget;
+        const slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
+        const carouselEl = e.target.querySelector('.carousel');
+        const carousel = bootstrap.Carousel.getOrCreateInstance(carouselEl);
         carousel.to(parseInt(slide, 10));
     });
 });
 </script>
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/layouts/shortcodes/tweet-archive.html
+++ b/layouts/shortcodes/tweet-archive.html
@@ -1,15 +1,14 @@
 {{- /* tweet-archive: embed an archived tweet by its tweet_id param */ -}}
 {{- $id := .Get "id" -}}
-{{- $tweet := false -}}
-{{- range where site.RegularPages "Params.tweet_id" $id -}}
-    {{- $tweet = . -}}
-{{- end -}}
-{{- if not $tweet -}}
+{{- $pages := where site.RegularPages "Params.tweet_id" $id -}}
+{{- if eq (len $pages) 0 -}}
     {{- errorf "tweet-archive: no content page found with tweet_id=%q" $id -}}
 {{- else -}}
+{{- $tweet := index $pages 0 -}}
 {{- $author := $tweet.Params.author | default "unknown" -}}
 {{- $authorName := $tweet.Params.author_name | default site.Params.biography.name -}}
-{{- $avatar := $tweet.Params.avatar | default (index site.Params.images 0) -}}
+{{- $avatar := $tweet.Params.avatar -}}
+{{- if not $avatar }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
 {{- $date := $tweet.Date -}}
 {{- $images := $tweet.Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
 {{- $imageCount := len $images -}}
@@ -22,15 +21,15 @@
                 <span class="tweet-archive-name">{{ $authorName }}</span>
                 <span class="tweet-archive-handle">@{{ $author }}</span>
             </div>
-            <span class="tweet-archive-badge" aria-label="This tweet has been archived"><i class="bi bi-archive" aria-hidden="true"></i> Archived</span>
+            <span class="tweet-archive-badge" aria-label="{{ i18n "tweet_archive.archived_label" }}"><i class="bi bi-archive" aria-hidden="true"></i> {{ i18n "tweet_archive.archived" }}</span>
         </div>
         <blockquote class="tweet-archive-text" cite="{{ $tweet.RelPermalink }}">{{ $tweet.Content }}</blockquote>
         {{- if gt $imageCount 0 }}
         <div class="tweet-archive-images grid-{{ cond (gt $imageCount 4) "4" (printf "%d" $imageCount) }}">
             {{- range $i, $img := $images }}
             {{- if lt $i 4 }}
-            <button type="button" class="tweet-archive-image-btn" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" data-bs-slide-to="{{ $i }}" aria-label="View photo {{ add $i 1 }} of {{ $imageCount }} in full screen">
-                <img src="{{ $img.RelPermalink }}" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}" loading="lazy">
+            <button type="button" class="tweet-archive-image-btn" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" data-bs-slide-to="{{ $i }}" aria-label="{{ printf (i18n "tweet_archive.view_photo") (add $i 1) $imageCount }}">
+                <img src="{{ $img.RelPermalink }}" alt="{{ i18n "tweet_archive.photo_label" }} {{ add $i 1 }}" loading="lazy">
             </button>
             {{- end }}
             {{- end }}
@@ -39,37 +38,37 @@
     </div>
     <figcaption class="tweet-archive-footer">
         <time class="tweet-archive-date" datetime="{{ $date.Format "2006-01-02T15:04:05Z07:00" }}">{{ $date.Format "January 2, 2006 · 15:04 UTC" }}</time>
-        <a href="{{ $tweet.RelPermalink }}" class="tweet-archive-link">View archived tweet <i class="bi bi-arrow-right" aria-hidden="true"></i></a>
+        <a href="{{ $tweet.RelPermalink }}" class="tweet-archive-link">{{ i18n "tweet_archive.view_archived_tweet" }} <i class="bi bi-arrow-right" aria-hidden="true"></i></a>
     </figcaption>
 </figure>
 {{- if gt $imageCount 0 }}
-<div class="modal fade tweet-archive-modal" id="{{ $modalId }}" tabindex="-1" aria-label="Tweet photo viewer" aria-hidden="true">
+<div class="modal fade tweet-archive-modal" id="{{ $modalId }}" tabindex="-1" aria-label="{{ i18n "tweet_archive.viewer_label" }}" aria-hidden="true">
     <div class="modal-dialog modal-xl modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header border-0">
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close photo viewer"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="{{ i18n "tweet_archive.close_viewer" }}"></button>
             </div>
             <div class="modal-body p-0">
                 <div id="{{ $modalId }}-carousel" class="carousel slide">
                     <div class="carousel-inner">
                         {{- range $i, $img := $images }}
                         <div class="carousel-item{{ if eq $i 0 }} active{{ end }}">
-                            <img src="{{ $img.RelPermalink }}" class="d-block mx-auto" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}">
+                            <img src="{{ $img.RelPermalink }}" class="d-block mx-auto" alt="{{ i18n "tweet_archive.photo_label" }} {{ add $i 1 }}">
                         </div>
                         {{- end }}
                     </div>
                     {{- if gt $imageCount 1 }}
                     <button class="carousel-control-prev" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="prev">
                         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                        <span class="visually-hidden">Previous photo</span>
+                        <span class="visually-hidden">{{ i18n "tweet_archive.previous_photo" }}</span>
                     </button>
                     <button class="carousel-control-next" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="next">
                         <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                        <span class="visually-hidden">Next photo</span>
+                        <span class="visually-hidden">{{ i18n "tweet_archive.next_photo" }}</span>
                     </button>
                     <div class="carousel-indicators">
                         {{- range $i, $img := $images }}
-                        <button type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide-to="{{ $i }}"{{ if eq $i 0 }} class="active" aria-current="true"{{ end }} aria-label="Photo {{ add $i 1 }}"></button>
+                        <button type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide-to="{{ $i }}"{{ if eq $i 0 }} class="active" aria-current="true"{{ end }} aria-label="{{ i18n "tweet_archive.photo_label" }} {{ add $i 1 }}"></button>
                         {{- end }}
                     </div>
                     {{- end }}

--- a/layouts/shortcodes/tweet-archive.html
+++ b/layouts/shortcodes/tweet-archive.html
@@ -1,0 +1,90 @@
+{{- /* tweet-archive: embed an archived tweet by its tweet_id param */ -}}
+{{- $id := .Get "id" -}}
+{{- $tweet := false -}}
+{{- range where site.RegularPages "Params.tweet_id" $id -}}
+    {{- $tweet = . -}}
+{{- end -}}
+{{- if not $tweet -}}
+    {{- errorf "tweet-archive: no content page found with tweet_id=%q" $id -}}
+{{- else -}}
+{{- $author := $tweet.Params.author | default "unknown" -}}
+{{- $authorName := $tweet.Params.author_name | default site.Params.biography.name -}}
+{{- $avatar := $tweet.Params.avatar | default (index site.Params.images 0) -}}
+{{- $date := $tweet.Date -}}
+{{- $images := $tweet.Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
+{{- $imageCount := len $images -}}
+{{- $modalId := printf "tweet-modal-%s" $id -}}
+<figure class="tweet-archive" role="figure" aria-label="Archived tweet by @{{ $author }}">
+    <div class="tweet-archive-body">
+        <div class="tweet-archive-header">
+            <img class="tweet-archive-avatar" src="{{ $avatar }}" alt="" aria-hidden="true">
+            <div class="tweet-archive-author">
+                <span class="tweet-archive-name">{{ $authorName }}</span>
+                <span class="tweet-archive-handle">@{{ $author }}</span>
+            </div>
+            <span class="tweet-archive-badge" aria-label="This tweet has been archived"><i class="bi bi-archive" aria-hidden="true"></i> Archived</span>
+        </div>
+        <blockquote class="tweet-archive-text" cite="{{ $tweet.RelPermalink }}">{{ $tweet.Content }}</blockquote>
+        {{- if gt $imageCount 0 }}
+        <div class="tweet-archive-images grid-{{ cond (gt $imageCount 4) "4" (printf "%d" $imageCount) }}">
+            {{- range $i, $img := $images }}
+            {{- if lt $i 4 }}
+            <button type="button" class="tweet-archive-image-btn" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" data-bs-slide-to="{{ $i }}" aria-label="View photo {{ add $i 1 }} of {{ $imageCount }} in full screen">
+                <img src="{{ $img.RelPermalink }}" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}" loading="lazy">
+            </button>
+            {{- end }}
+            {{- end }}
+        </div>
+        {{- end }}
+    </div>
+    <figcaption class="tweet-archive-footer">
+        <time class="tweet-archive-date" datetime="{{ $date.Format "2006-01-02T15:04:05Z07:00" }}">{{ $date.Format "January 2, 2006 · 15:04 UTC" }}</time>
+        <a href="{{ $tweet.RelPermalink }}" class="tweet-archive-link">View archived tweet <i class="bi bi-arrow-right" aria-hidden="true"></i></a>
+    </figcaption>
+</figure>
+{{- if gt $imageCount 0 }}
+<div class="modal fade tweet-archive-modal" id="{{ $modalId }}" tabindex="-1" aria-label="Tweet photo viewer" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close photo viewer"></button>
+            </div>
+            <div class="modal-body p-0">
+                <div id="{{ $modalId }}-carousel" class="carousel slide">
+                    <div class="carousel-inner">
+                        {{- range $i, $img := $images }}
+                        <div class="carousel-item{{ if eq $i 0 }} active{{ end }}">
+                            <img src="{{ $img.RelPermalink }}" class="d-block mx-auto" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}">
+                        </div>
+                        {{- end }}
+                    </div>
+                    {{- if gt $imageCount 1 }}
+                    <button class="carousel-control-prev" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="prev">
+                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                        <span class="visually-hidden">Previous photo</span>
+                    </button>
+                    <button class="carousel-control-next" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="next">
+                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                        <span class="visually-hidden">Next photo</span>
+                    </button>
+                    <div class="carousel-indicators">
+                        {{- range $i, $img := $images }}
+                        <button type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide-to="{{ $i }}"{{ if eq $i 0 }} class="active" aria-current="true"{{ end }} aria-label="Photo {{ add $i 1 }}"></button>
+                        {{- end }}
+                    </div>
+                    {{- end }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
+    var trigger = e.relatedTarget;
+    var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
+    var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
+    carousel.to(parseInt(slide, 10));
+});
+</script>
+{{- end }}
+{{- end -}}

--- a/layouts/tweets/single.html
+++ b/layouts/tweets/single.html
@@ -1,0 +1,82 @@
+{{ define "main"}}
+{{- $author := .Params.author | default "unknown" -}}
+{{- $authorName := .Params.author_name | default site.Params.biography.name -}}
+{{- $avatar := .Params.avatar | default (index site.Params.images 0) -}}
+{{- $images := .Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
+{{- $imageCount := len $images -}}
+{{- $modalId := printf "tweet-modal-%s" .Params.tweet_id -}}
+
+<figure class="tweet-archive standalone" role="figure" aria-label="Archived tweet by @{{ $author }}">
+    <div class="tweet-archive-body">
+        <div class="tweet-archive-header">
+            <img class="tweet-archive-avatar" src="{{ $avatar }}" alt="" aria-hidden="true">
+            <div class="tweet-archive-author">
+                <span class="tweet-archive-name">{{ $authorName }}</span>
+                <span class="tweet-archive-handle">@{{ $author }}</span>
+            </div>
+            <span class="tweet-archive-badge" aria-label="This tweet has been archived"><i class="bi bi-archive" aria-hidden="true"></i> Archived</span>
+        </div>
+        <blockquote class="tweet-archive-text" cite="{{ .Permalink }}">{{ .Content }}</blockquote>
+        {{- if gt $imageCount 0 }}
+        <div class="tweet-archive-images grid-{{ cond (gt $imageCount 4) "4" (printf "%d" $imageCount) }}">
+            {{- range $i, $img := $images }}
+            {{- if lt $i 4 }}
+            <button type="button" class="tweet-archive-image-btn" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" data-bs-slide-to="{{ $i }}" aria-label="View photo {{ add $i 1 }} of {{ $imageCount }} in full screen">
+                <img src="{{ $img.RelPermalink }}" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}" loading="lazy">
+            </button>
+            {{- end }}
+            {{- end }}
+        </div>
+        {{- end }}
+    </div>
+    <figcaption class="tweet-archive-footer">
+        <time class="tweet-archive-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006 · 15:04 UTC" }}</time>
+    </figcaption>
+</figure>
+
+{{- if gt $imageCount 0 }}
+<div class="modal fade tweet-archive-modal" id="{{ $modalId }}" tabindex="-1" aria-label="Tweet photo viewer" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close photo viewer"></button>
+            </div>
+            <div class="modal-body p-0">
+                <div id="{{ $modalId }}-carousel" class="carousel slide">
+                    <div class="carousel-inner">
+                        {{- range $i, $img := $images }}
+                        <div class="carousel-item{{ if eq $i 0 }} active{{ end }}">
+                            <img src="{{ $img.RelPermalink }}" class="d-block mx-auto" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}">
+                        </div>
+                        {{- end }}
+                    </div>
+                    {{- if gt $imageCount 1 }}
+                    <button class="carousel-control-prev" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="prev">
+                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                        <span class="visually-hidden">Previous photo</span>
+                    </button>
+                    <button class="carousel-control-next" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="next">
+                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                        <span class="visually-hidden">Next photo</span>
+                    </button>
+                    <div class="carousel-indicators">
+                        {{- range $i, $img := $images }}
+                        <button type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide-to="{{ $i }}"{{ if eq $i 0 }} class="active" aria-current="true"{{ end }} aria-label="Photo {{ add $i 1 }}"></button>
+                        {{- end }}
+                    </div>
+                    {{- end }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
+    var trigger = e.relatedTarget;
+    var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
+    var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
+    carousel.to(parseInt(slide, 10));
+});
+</script>
+{{- end }}
+{{ end }}

--- a/layouts/tweets/single.html
+++ b/layouts/tweets/single.html
@@ -1,7 +1,8 @@
 {{ define "main"}}
 {{- $author := .Params.author | default "unknown" -}}
 {{- $authorName := .Params.author_name | default site.Params.biography.name -}}
-{{- $avatar := .Params.avatar | default (index site.Params.images 0) -}}
+{{- $avatar := .Params.avatar -}}
+{{- if not $avatar }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
 {{- $images := .Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
 {{- $imageCount := len $images -}}
 {{- $modalId := printf "tweet-modal-%s" .Params.tweet_id -}}
@@ -14,15 +15,15 @@
                 <span class="tweet-archive-name">{{ $authorName }}</span>
                 <span class="tweet-archive-handle">@{{ $author }}</span>
             </div>
-            <span class="tweet-archive-badge" aria-label="This tweet has been archived"><i class="bi bi-archive" aria-hidden="true"></i> Archived</span>
+            <span class="tweet-archive-badge" aria-label="{{ i18n "tweet_archive.archived_label" }}"><i class="bi bi-archive" aria-hidden="true"></i> {{ i18n "tweet_archive.archived" }}</span>
         </div>
         <blockquote class="tweet-archive-text" cite="{{ .Permalink }}">{{ .Content }}</blockquote>
         {{- if gt $imageCount 0 }}
         <div class="tweet-archive-images grid-{{ cond (gt $imageCount 4) "4" (printf "%d" $imageCount) }}">
             {{- range $i, $img := $images }}
             {{- if lt $i 4 }}
-            <button type="button" class="tweet-archive-image-btn" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" data-bs-slide-to="{{ $i }}" aria-label="View photo {{ add $i 1 }} of {{ $imageCount }} in full screen">
-                <img src="{{ $img.RelPermalink }}" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}" loading="lazy">
+            <button type="button" class="tweet-archive-image-btn" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" data-bs-slide-to="{{ $i }}" aria-label="{{ printf (i18n "tweet_archive.view_photo") (add $i 1) $imageCount }}">
+                <img src="{{ $img.RelPermalink }}" alt="{{ i18n "tweet_archive.photo_label" }} {{ add $i 1 }}" loading="lazy">
             </button>
             {{- end }}
             {{- end }}
@@ -35,33 +36,33 @@
 </figure>
 
 {{- if gt $imageCount 0 }}
-<div class="modal fade tweet-archive-modal" id="{{ $modalId }}" tabindex="-1" aria-label="Tweet photo viewer" aria-hidden="true">
+<div class="modal fade tweet-archive-modal" id="{{ $modalId }}" tabindex="-1" aria-label="{{ i18n "tweet_archive.viewer_label" }}" aria-hidden="true">
     <div class="modal-dialog modal-xl modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header border-0">
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close photo viewer"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="{{ i18n "tweet_archive.close_viewer" }}"></button>
             </div>
             <div class="modal-body p-0">
                 <div id="{{ $modalId }}-carousel" class="carousel slide">
                     <div class="carousel-inner">
                         {{- range $i, $img := $images }}
                         <div class="carousel-item{{ if eq $i 0 }} active{{ end }}">
-                            <img src="{{ $img.RelPermalink }}" class="d-block mx-auto" alt="Photo {{ add $i 1 }} from archived tweet by @{{ $author }}">
+                            <img src="{{ $img.RelPermalink }}" class="d-block mx-auto" alt="{{ i18n "tweet_archive.photo_label" }} {{ add $i 1 }}">
                         </div>
                         {{- end }}
                     </div>
                     {{- if gt $imageCount 1 }}
                     <button class="carousel-control-prev" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="prev">
                         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                        <span class="visually-hidden">Previous photo</span>
+                        <span class="visually-hidden">{{ i18n "tweet_archive.previous_photo" }}</span>
                     </button>
                     <button class="carousel-control-next" type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide="next">
                         <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                        <span class="visually-hidden">Next photo</span>
+                        <span class="visually-hidden">{{ i18n "tweet_archive.next_photo" }}</span>
                     </button>
                     <div class="carousel-indicators">
                         {{- range $i, $img := $images }}
-                        <button type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide-to="{{ $i }}"{{ if eq $i 0 }} class="active" aria-current="true"{{ end }} aria-label="Photo {{ add $i 1 }}"></button>
+                        <button type="button" data-bs-target="#{{ $modalId }}-carousel" data-bs-slide-to="{{ $i }}"{{ if eq $i 0 }} class="active" aria-current="true"{{ end }} aria-label="{{ i18n "tweet_archive.photo_label" }} {{ add $i 1 }}"></button>
                         {{- end }}
                     </div>
                     {{- end }}

--- a/layouts/tweets/single.html
+++ b/layouts/tweets/single.html
@@ -2,7 +2,7 @@
 {{- $author := .Params.author | default "unknown" -}}
 {{- $authorName := .Params.author_name | default site.Params.biography.name -}}
 {{- $avatar := .Params.avatar -}}
-{{- if not $avatar }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
+{{- if $avatar }}{{ $avatar = partial "resolve-image-path.html" (dict "src" $avatar "file" .File) }}{{ else }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
 {{- $images := .Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
 {{- $imageCount := len $images -}}
 {{- $modalId := printf "tweet-modal-%s" .Params.tweet_id -}}
@@ -17,7 +17,7 @@
             </div>
             <span class="tweet-archive-badge" aria-label="{{ i18n "tweet_archive.archived_label" }}"><i class="bi bi-archive" aria-hidden="true"></i> {{ i18n "tweet_archive.archived" }}</span>
         </div>
-        <blockquote class="tweet-archive-text" cite="{{ .Permalink }}">{{ .Content }}</blockquote>
+        <blockquote class="tweet-archive-text" cite="{{ .RelPermalink }}">{{ .Content }}</blockquote>
         {{- if gt $imageCount 0 }}
         <div class="tweet-archive-images grid-{{ cond (gt $imageCount 4) "4" (printf "%d" $imageCount) }}">
             {{- range $i, $img := $images }}
@@ -31,7 +31,7 @@
         {{- end }}
     </div>
     <figcaption class="tweet-archive-footer">
-        <time class="tweet-archive-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006 · 15:04 UTC" }}</time>
+        <time class="tweet-archive-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ time.Format "January 2, 2006 · 15:04" .Date }} UTC</time>
     </figcaption>
 </figure>
 
@@ -72,11 +72,13 @@
     </div>
 </div>
 <script>
-document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
-    var trigger = e.relatedTarget;
-    var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
-    var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
-    carousel.to(parseInt(slide, 10));
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
+        var trigger = e.relatedTarget;
+        var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
+        var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
+        carousel.to(parseInt(slide, 10));
+    });
 });
 </script>
 {{- end }}

--- a/layouts/tweets/single.html
+++ b/layouts/tweets/single.html
@@ -3,14 +3,18 @@
 {{- $authorName := .Params.author_name | default site.Params.biography.name -}}
 {{- $avatar := .Params.avatar -}}
 {{- if $avatar }}{{ $avatar = partial "resolve-image-path.html" (dict "src" $avatar "file" .File) }}{{ else }}{{ with site.Params.images }}{{ $avatar = index . 0 }}{{ end }}{{ end -}}
-{{- $images := .Resources.Match "*.{jpg,jpeg,png,gif,webp}" -}}
+{{- $allImages := .Resources.ByType "image" -}}
+{{- $images := slice -}}
+{{- range $allImages }}{{ if not (strings.HasPrefix .Name "avatar") }}{{ $images = $images | append . }}{{ end }}{{ end -}}
 {{- $imageCount := len $images -}}
 {{- $modalId := printf "tweet-modal-%s" .Params.tweet_id -}}
 
 <figure class="tweet-archive standalone" role="figure" aria-label="Archived tweet by @{{ $author }}">
     <div class="tweet-archive-body">
         <div class="tweet-archive-header">
-            <img class="tweet-archive-avatar" src="{{ $avatar }}" alt="" aria-hidden="true">
+            {{- with $avatar }}
+            <img class="tweet-archive-avatar" src="{{ . }}" alt="{{ $authorName }} avatar">
+            {{- end }}
             <div class="tweet-archive-author">
                 <span class="tweet-archive-name">{{ $authorName }}</span>
                 <span class="tweet-archive-handle">@{{ $author }}</span>
@@ -73,10 +77,12 @@
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    document.querySelector('#{{ $modalId }}').addEventListener('show.bs.modal', function(e) {
-        var trigger = e.relatedTarget;
-        var slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
-        var carousel = bootstrap.Carousel.getOrCreateInstance(document.querySelector('#{{ $modalId }}-carousel'));
+    document.addEventListener('show.bs.modal', function(e) {
+        if (!e.target.classList.contains('tweet-archive-modal')) return;
+        const trigger = e.relatedTarget;
+        const slide = trigger ? trigger.getAttribute('data-bs-slide-to') : '0';
+        const carouselEl = e.target.querySelector('.carousel');
+        const carousel = bootstrap.Carousel.getOrCreateInstance(carouselEl);
         carousel.to(parseInt(slide, 10));
     });
 });


### PR DESCRIPTION
Add a self-hosted tweet archive system for preserving tweets from deleted or inaccessible Twitter/X accounts. Each archived tweet is a Hugo page bundle with its own URL, images, and metadata — no external dependencies or JavaScript embeds.

The `tweet-archive` shortcode renders a styled card with author avatar, display name, handle, "Archived" badge, tweet text, and an adaptive image grid. Clicking any image opens a full-screen Bootstrap modal carousel starting on the clicked photo. The card is centered at 550px max-width when embedded in blog posts and full viewport width on standalone tweet pages.

Image grid adapts to photo count: 1 photo displays at natural aspect ratio, 2 side-by-side, 3 with the first full-width above two smaller, and 4 in a 2×2 grid.

The shortcode looks up tweet content pages by their `tweet_id` front- matter param. If no matching page is found, Hugo errors at build time to prevent silent broken embeds.

Add word-break rules for long unbreakable strings (hashtags, URLs, compound words) on h1 elements and within main content to prevent horizontal overflow on narrow viewports.

Accessibility: semantic `figure`/`blockquote`/`figcaption` markup, keyboard-navigable image buttons with `:focus-visible` outlines, descriptive `aria-labels` on all interactive elements, and `prefers-reduced-motion` support.

Document the tweet archive feature in `README.md` and `AGENTS.md` including content model, layout hierarchy, image grid behavior, shortcode usage, and accessibility details.

Related to https://github.com/justwheel/jwheel.org/issues/12.