### PR TITLE
✨ css: Add print stylesheet for clean printed output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ assets/css/
     _global.css                   Body, headings, anchor links
     _nav.css                      Fixed navbar, dropdowns, hover states
     _content.css                  Main body: links, images, figures, ToC, profile
+    _print.css                    Print stylesheet: hides navbar/UI, page numbering
   components/
     _cover.css                    Cover image for blog posts
     _hero.css                     Homepage hero section

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Toph: a lightweight, responsive theme for a biography site, for use with [Hugo](
 - First-class support for both Markdown and AsciiDoc content
 - [Search engine optimization](#search-engine-optimization): meta description, canonical URL, hreflang, structured data (WebSite, Person, Article, BreadcrumbList JSON-LD)
 - 404 page with localized "Return to homepage" link
+- [Print-friendly output](#print-stylesheet) with page numbering
 - [Easy customization of colors and fonts in Hugo configuration](#custom-colors-and-fonts)
 
 
@@ -449,6 +450,19 @@ Brand colors (`--primary`, `--secondary`, `--accent-color`) and fonts are set fr
 Both sets of variables coexist on `:root` without conflict.
 
 To add new CSS for a new component, create a new `_component-name.css` file in the appropriate directory and add an `@import` line to `main.css`.
+
+### Print stylesheet
+
+Toph includes a print stylesheet that produces clean, readable output when a page is printed or saved as PDF.
+No configuration is needed — the styles apply automatically via `@media print`.
+
+When printing:
+- The fixed navbar is hidden
+- Interactive elements (carousels, lightbox modals, heading anchors, pagination, post navigation) are removed
+- External link URLs are shown in parentheses after the link text
+- Colors are simplified to black text on a white background
+- Images and headings avoid breaking across page boundaries
+- Page numbers ("Page X of Y") appear at the bottom of each page (Chromium-based browsers; Firefox users can enable page numbers via the print dialog)
 
 ### Custom colors and fonts
 

--- a/assets/css/base/_print.css
+++ b/assets/css/base/_print.css
@@ -1,0 +1,119 @@
+/* ===[ Print stylesheet ]=== */
+
+@media print {
+  /* Remove the fixed navbar entirely */
+  .navbar {
+    display: none !important;
+  }
+
+  /* Remove the large top padding that compensates for the fixed navbar */
+  h1 {
+    padding-top: 1rem;
+  }
+
+  /* Use print-friendly colors */
+  body {
+    background-color: #fff;
+    color: #000;
+  }
+
+  /* Ensure content uses full page width */
+  .container {
+    max-width: 100%;
+  }
+
+  /* Hide interactive and navigational elements */
+  .post-nav,
+  .carousel-control-prev,
+  .carousel-control-next,
+  .carousel-indicators,
+  .tweet-archive-modal,
+  .tweet-archive-link,
+  .tweet-archive-image-btn {
+    display: none !important;
+  }
+
+  /* Let tweet images display inline for print instead of as buttons */
+  .tweet-archive-images img {
+    max-height: none;
+    page-break-inside: avoid;
+  }
+
+  /* Hide footer badges, keep the copyright text */
+  footer .container-fluid:first-child {
+    display: none;
+  }
+
+  /* Remove footer background color for print */
+  footer #footer-box {
+    background-color: transparent;
+    color: #000;
+  }
+
+  footer #footer-box a {
+    color: #000;
+  }
+
+  /* Hide heading anchor links */
+  .hanchor {
+    display: none !important;
+  }
+
+  /* Show link URLs after anchors in the main content area */
+  main a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    font-weight: normal;
+    word-break: break-all;
+  }
+
+  /* Do not show URLs for navigation or UI links */
+  nav a::after,
+  footer a::after,
+  .tweet-archive a::after,
+  .pagination a::after {
+    content: none !important;
+  }
+
+  /* Prevent awkward page breaks */
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+
+  img, figure, blockquote, pre {
+    page-break-inside: avoid;
+  }
+
+  /* Hide the hero social links and "for hire" banner */
+  .hero-links,
+  .for-hire {
+    display: none !important;
+  }
+
+  /* Hide pagination */
+  .pagination {
+    display: none !important;
+  }
+
+  /* Hide the projects carousel */
+  #projects-carousel {
+    display: none !important;
+  }
+}
+
+/* Page numbering for printed output.
+ * Uses CSS @page margin boxes to render "Page X of Y" centered
+ * at the bottom of every printed page. Supported in Chromium-based
+ * browsers (Chrome, Edge). Firefox ignores @page margin boxes
+ * entirely — users can enable page numbers via the browser's
+ * print dialog (Headers and Footers checkbox). */
+@page {
+  margin: 2cm;
+
+  @bottom-center {
+    content: "Page " counter(page) " of " counter(pages);
+    font-family: var(--default-font), sans-serif;
+    font-size: 0.75rem;
+    color: #767676;
+  }
+}

--- a/assets/css/base/_print.css
+++ b/assets/css/base/_print.css
@@ -35,8 +35,8 @@
 
   /* Let tweet images display inline for print instead of as buttons */
   .tweet-archive-images img {
+    break-inside: avoid;
     max-height: none;
-    page-break-inside: avoid;
   }
 
   /* Hide footer badges, keep the copyright text */
@@ -77,11 +77,11 @@
 
   /* Prevent awkward page breaks */
   h1, h2, h3, h4, h5, h6 {
-    page-break-after: avoid;
+    break-after: avoid;
   }
 
   img, figure, blockquote, pre {
-    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   /* Hide the hero social links and "for hire" banner */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -11,6 +11,7 @@
 @import './base/_global.css';
 @import './base/_nav.css';
 @import './base/_content.css';
+@import './base/_print.css';
 
 /* Page components */
 @import './components/_cover.css';


### PR DESCRIPTION
When printing a page from the site (Ctrl+P or browser print), the fixed navbar appeared on every printed page, covering content and making the output unreadable. Other interactive elements like carousels, lightbox modals, heading anchors, and pagination also cluttered the print result.

Add a dedicated print stylesheet that produces clean, readable printed output by hiding the navbar, interactive controls, and decorative elements while preserving the article content, images, and copyright notice. External link URLs are shown in parentheses after the link text so readers of the printed document can find the original sources.

Page numbering ("Page X of Y") is rendered at the bottom center of every page using CSS `@page` margin boxes. This is supported in Chromium-based browsers (Chrome, Edge). Firefox does not support `@page` margin boxes, so users can enable page numbers via the browser's print dialog instead.

Document the print stylesheet in `README.md` with a feature description and in `AGENTS.md`'s CSS file structure listing.