### PR TITLE
♻ css: Convert properties for full RTL support (closes #64)

### DIFF
--- a/assets/css/base/_nav.css
+++ b/assets/css/base/_nav.css
@@ -98,7 +98,7 @@
   .nav-hover-dropdown > .dropdown-menu {
     border: none;
     display: block;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
     position: static;
   }
 }

--- a/assets/css/blog/_blog-archive.css
+++ b/assets/css/blog/_blog-archive.css
@@ -54,10 +54,10 @@
 
 /* Post entries within the archive */
 .archive-posts .list-group-item {
-  border-left: 3px solid transparent;
-  transition: border-left-color 0.15s ease;
+  border-inline-start: 3px solid transparent;
+  transition: border-inline-start-color 0.15s ease;
 }
 
 .archive-posts .list-group-item:hover {
-  border-left-color: var(--primary);
+  border-inline-start-color: var(--primary);
 }

--- a/assets/css/blog/_recent-posts.css
+++ b/assets/css/blog/_recent-posts.css
@@ -80,20 +80,20 @@
 .recent-featured,
 .recent-card {
   position: relative;
-  border-left: 4px solid var(--accent-color);
-  transition: background-color 0.15s ease, border-left-color 0.15s ease;
+  border-inline-start: 4px solid var(--accent-color);
+  transition: background-color 0.15s ease, border-inline-start-color 0.15s ease;
 }
 
 .recent-featured:hover,
 .recent-card:hover {
   background-color: var(--bg-card-hover);
-  border-left-color: var(--primary);
+  border-inline-start-color: var(--primary);
 }
 
 .recent-featured:active,
 .recent-card:active {
   background-color: var(--bg-card-active);
-  border-left-color: var(--secondary);
+  border-inline-start-color: var(--secondary);
 }
 
 .recent-card-title {

--- a/assets/css/components/_asciidoc-admonition.css
+++ b/assets/css/components/_asciidoc-admonition.css
@@ -10,7 +10,7 @@ main .admonitionblock {
 main .admonitionblock table {
   background: var(--admonition-bg-note);
   border: none;
-  border-left: 4px solid var(--admonition-border-note);
+  border-inline-start: 4px solid var(--admonition-border-note);
   border-radius: 4px;
   display: flex;
   padding: 1rem 1.25rem;
@@ -30,7 +30,7 @@ main .admonitionblock td.icon {
   display: flex;
   flex-shrink: 0;
   padding: 0;
-  padding-right: 1rem;
+  padding-inline-end: 1rem;
   padding-top: 0.15rem;
 }
 
@@ -95,7 +95,7 @@ main .admonitionblock.note td.icon::before {
 /* Tip */
 main .admonitionblock.tip table {
   background: var(--admonition-bg-tip);
-  border-left-color: var(--admonition-border-tip);
+  border-inline-start-color: var(--admonition-border-tip);
 }
 
 main .admonitionblock.tip td.icon::before {
@@ -106,7 +106,7 @@ main .admonitionblock.tip td.icon::before {
 /* Warning */
 main .admonitionblock.warning table {
   background: var(--admonition-bg-warning);
-  border-left-color: var(--admonition-border-warning);
+  border-inline-start-color: var(--admonition-border-warning);
 }
 
 main .admonitionblock.warning td.icon::before {
@@ -117,7 +117,7 @@ main .admonitionblock.warning td.icon::before {
 /* Caution */
 main .admonitionblock.caution table {
   background: var(--admonition-bg-caution);
-  border-left-color: var(--admonition-border-caution);
+  border-inline-start-color: var(--admonition-border-caution);
 }
 
 main .admonitionblock.caution td.icon::before {
@@ -128,7 +128,7 @@ main .admonitionblock.caution td.icon::before {
 /* Important */
 main .admonitionblock.important table {
   background: var(--admonition-bg-important);
-  border-left-color: var(--admonition-border-important);
+  border-inline-start-color: var(--admonition-border-important);
 }
 
 main .admonitionblock.important td.icon::before {
@@ -144,7 +144,7 @@ main .admonitionblock.important td.icon::before {
 
   main .admonitionblock table {
     background: #fff !important;
-    border-left-color: #555 !important;
+    border-inline-start-color: #555 !important;
   }
 
   main .admonitionblock td.icon::before {

--- a/assets/css/components/_team.css
+++ b/assets/css/components/_team.css
@@ -21,7 +21,7 @@
 .team-card {
   background: var(--bg-white);
   border: 1px solid var(--border-light);
-  border-left: 4px solid var(--accent-color);
+  border-inline-start: 4px solid var(--accent-color);
   border-radius: 4px;
   padding: 1.25rem;
   display: flex;
@@ -29,18 +29,18 @@
   align-items: center;
   text-align: center;
   position: relative;
-  transition: background-color 0.15s ease, border-left-color 0.15s ease, box-shadow 0.2s ease;
+  transition: background-color 0.15s ease, border-inline-start-color 0.15s ease, box-shadow 0.2s ease;
 }
 
 .team-card:hover {
   background-color: var(--bg-card-hover);
-  border-left-color: var(--primary);
+  border-inline-start-color: var(--primary);
   box-shadow: 0 4px 12px var(--shadow-card);
 }
 
 .team-card:active {
   background-color: var(--bg-card-active);
-  border-left-color: var(--secondary);
+  border-inline-start-color: var(--secondary);
 }
 
 /* Circular profile photo with grayscale filter */

--- a/assets/css/components/_tweet-archive.css
+++ b/assets/css/components/_tweet-archive.css
@@ -3,7 +3,7 @@
 .tweet-archive {
   background-color: var(--bg-white);
   border: 1px solid var(--border-card);
-  border-left: 4px solid var(--accent-color);
+  border-inline-start: 4px solid var(--accent-color);
   border-radius: 0.5rem;
   margin: 1.5rem auto;
   max-width: 550px;

--- a/assets/css/taxonomy/_categories.css
+++ b/assets/css/taxonomy/_categories.css
@@ -41,7 +41,7 @@
   gap: 1rem;
   background: var(--bg-white);
   border: 1px solid var(--border-light);
-  border-left: 4px solid var(--accent-color);
+  border-inline-start: 4px solid var(--accent-color);
   border-radius: 4px;
   padding: 1rem;
   height: 100%;
@@ -50,7 +50,7 @@
 
 .category-card-inner:hover {
   box-shadow: 0 4px 12px var(--shadow-card);
-  border-left-color: var(--primary);
+  border-inline-start-color: var(--primary);
 }
 
 /*

--- a/assets/css/taxonomy/_tags.css
+++ b/assets/css/taxonomy/_tags.css
@@ -39,6 +39,9 @@
 .tags-sort-btn:last-child {
   border-start-end-radius: 4px;
   border-end-end-radius: 4px;
+}
+
+.tags-sort-btn:not(:first-child) {
   border-inline-start: none;
 }
 

--- a/assets/css/taxonomy/_tags.css
+++ b/assets/css/taxonomy/_tags.css
@@ -30,14 +30,16 @@
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-/* First button gets rounded left corners, last gets rounded right */
+/* First button gets rounded start corners, last gets rounded end corners */
 .tags-sort-btn:first-child {
-  border-radius: 4px 0 0 4px;
+  border-start-start-radius: 4px;
+  border-end-start-radius: 4px;
 }
 
 .tags-sort-btn:last-child {
-  border-radius: 0 4px 4px 0;
-  border-left: none;
+  border-start-end-radius: 4px;
+  border-end-end-radius: 4px;
+  border-inline-start: none;
 }
 
 /* Active sort button uses the theme's primary color */

--- a/assets/css/taxonomy/_terms-controls.css
+++ b/assets/css/taxonomy/_terms-controls.css
@@ -36,6 +36,9 @@
 .terms-sort-btn:last-child {
   border-start-end-radius: 4px;
   border-end-end-radius: 4px;
+}
+
+.terms-sort-btn:not(:first-child) {
   border-inline-start: none;
 }
 

--- a/assets/css/taxonomy/_terms-controls.css
+++ b/assets/css/taxonomy/_terms-controls.css
@@ -29,12 +29,14 @@
 }
 
 .terms-sort-btn:first-child {
-  border-radius: 4px 0 0 4px;
+  border-start-start-radius: 4px;
+  border-end-start-radius: 4px;
 }
 
 .terms-sort-btn:last-child {
-  border-radius: 0 4px 4px 0;
-  border-left: none;
+  border-start-end-radius: 4px;
+  border-end-end-radius: 4px;
+  border-inline-start: none;
 }
 
 .terms-sort-btn.active {


### PR DESCRIPTION
The theme actively supports RTL (Arabic is a configured language with `direction: rtl`, and `baseof.html` sets `dir` on `<html>` from it), but every card-style component used physical directional properties (`border-left`, `padding-right`/`padding-left`) instead of logical properties (`border-inline-start`, `padding-inline-end`/ `padding-inline-start`). In an RTL context, these accent borders and padding rendered on the wrong side.

Convert all affected declarations across the admonition, tweet archive, team, blog archive, recent posts, categories, tags, terms controls, and nav components. `border-left-color` transition targets are updated to `border-inline-start-color` to match.

While auditing these files, the tags and terms-controls sort-button groups were found to have the same physical-direction bug in their corner rounding (`border-radius: 4px 0 0 4px` on `:first-child`, mirrored on `:last-child`), which would round the wrong corners once the button group's visual order flips in RTL. Converted both to the logical corner-radius properties (`border-start-start-radius`, `border-end-start-radius`, `border-start-end-radius`, `border-end-end-radius`) in the same pass, since it shares the exact root cause as the properties this issue already tracks.

Closes #64.