### PR TITLE
🌐 exampleSite: Localize navbar labels and links per language

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -175,9 +175,93 @@ languages:
   ar:
     direction: rtl
     label: عربي
+    menu:
+      nav:
+        - identifier: home
+          name: الرئيسية
+          url: /ar/
+          weight: 10
+        - identifier: about
+          name: نبذة عني
+          url: https://kinginstitute.stanford.edu/encyclopedia/clark-septima-poinsette
+          weight: 20
+        - identifier: team
+          name: قادة رفاق
+          url: /ar/team/
+          weight: 30
+        - identifier: blog
+          name: المدونة
+          url: /ar/blog/
+          weight: 40
+        - identifier: categories
+          name: الفئات
+          url: /ar/categories/
+          parent: blog
+          weight: 10
+        - identifier: tags
+          name: الوسوم
+          url: /ar/tags/
+          parent: blog
+          weight: 20
   en:
     label: English
   es:
     label: español
+    menu:
+      nav:
+        - identifier: home
+          name: inicio
+          url: /es/
+          weight: 10
+        - identifier: about
+          name: sobre mí
+          url: https://kinginstitute.stanford.edu/encyclopedia/clark-septima-poinsette
+          weight: 20
+        - identifier: team
+          name: compañeros líderes
+          url: /es/team/
+          weight: 30
+        - identifier: blog
+          name: blog
+          url: /es/blog/
+          weight: 40
+        - identifier: categories
+          name: categorías
+          url: /es/categories/
+          parent: blog
+          weight: 10
+        - identifier: tags
+          name: etiquetas
+          url: /es/tags/
+          parent: blog
+          weight: 20
   hi:
     label: हिन्दी
+    menu:
+      nav:
+        - identifier: home
+          name: होम
+          url: /hi/
+          weight: 10
+        - identifier: about
+          name: मेरे बारे में
+          url: https://kinginstitute.stanford.edu/encyclopedia/clark-septima-poinsette
+          weight: 20
+        - identifier: team
+          name: साथी नेता
+          url: /hi/team/
+          weight: 30
+        - identifier: blog
+          name: ब्लॉग
+          url: /hi/blog/
+          weight: 40
+        - identifier: categories
+          name: श्रेणियां
+          url: /hi/categories/
+          parent: blog
+          weight: 10
+        - identifier: tags
+          name: टैग
+          url: /hi/tags/
+          parent: blog
+          weight: 20

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -63,7 +63,7 @@ menu:
   nav:
     - identifier: home
       name: home
-      url: /
+      pageRef: /
       weight: 10
     - identifier: about
       name: about me
@@ -71,20 +71,20 @@ menu:
       weight: 20
     - identifier: team
       name: fellow leaders
-      url: /team/
+      pageRef: /team
       weight: 30
     - identifier: blog
       name: blog
-      url: /blog/
+      pageRef: /blog
       weight: 40
     - identifier: categories
       name: categories
-      url: /categories/
+      pageRef: /categories
       parent: blog
       weight: 10
     - identifier: tags
       name: tags
-      url: /tags/
+      pageRef: /tags
       parent: blog
       weight: 20
 
@@ -179,7 +179,7 @@ languages:
       nav:
         - identifier: home
           name: الرئيسية
-          url: /ar/
+          pageRef: /
           weight: 10
         - identifier: about
           name: نبذة عني
@@ -187,20 +187,20 @@ languages:
           weight: 20
         - identifier: team
           name: قادة رفاق
-          url: /ar/team/
+          pageRef: /team
           weight: 30
         - identifier: blog
           name: المدونة
-          url: /ar/blog/
+          pageRef: /blog
           weight: 40
         - identifier: categories
           name: الفئات
-          url: /ar/categories/
+          pageRef: /categories
           parent: blog
           weight: 10
         - identifier: tags
           name: الوسوم
-          url: /ar/tags/
+          pageRef: /tags
           parent: blog
           weight: 20
   en:
@@ -211,7 +211,7 @@ languages:
       nav:
         - identifier: home
           name: inicio
-          url: /es/
+          pageRef: /
           weight: 10
         - identifier: about
           name: sobre mí
@@ -219,20 +219,20 @@ languages:
           weight: 20
         - identifier: team
           name: compañeros líderes
-          url: /es/team/
+          pageRef: /team
           weight: 30
         - identifier: blog
           name: blog
-          url: /es/blog/
+          pageRef: /blog
           weight: 40
         - identifier: categories
           name: categorías
-          url: /es/categories/
+          pageRef: /categories
           parent: blog
           weight: 10
         - identifier: tags
           name: etiquetas
-          url: /es/tags/
+          pageRef: /tags
           parent: blog
           weight: 20
   hi:
@@ -241,7 +241,7 @@ languages:
       nav:
         - identifier: home
           name: होम
-          url: /hi/
+          pageRef: /
           weight: 10
         - identifier: about
           name: मेरे बारे में
@@ -249,19 +249,19 @@ languages:
           weight: 20
         - identifier: team
           name: साथी नेता
-          url: /hi/team/
+          pageRef: /team
           weight: 30
         - identifier: blog
           name: ब्लॉग
-          url: /hi/blog/
+          pageRef: /blog
           weight: 40
         - identifier: categories
           name: श्रेणियां
-          url: /hi/categories/
+          pageRef: /categories
           parent: blog
           weight: 10
         - identifier: tags
           name: टैग
-          url: /hi/tags/
+          pageRef: /tags
           parent: blog
           weight: 20

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
-        <a class="navbar-brand" href="{{ "/" | relLangURL }}">{{ site.Title }}</a>
+        <a class="navbar-brand" href="{{ site.Home.RelPermalink }}">{{ site.Title }}</a>
         <button class="navbar-toggler bg-light" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>


### PR DESCRIPTION
The navbar was the last major piece of exampleSite still hardcoded to English after the content translation pass. Add a `menu.nav` override per language in `config.yaml` with translated labels and language- prefixed URLs.

Each override redefines the full six-item menu rather than just the translated fields, since Hugo replaces `menu.nav` wholesale per language instead of merging it. The "about me" link stays unchanged in every language — no verified translated version of that external page exists to link to.